### PR TITLE
fix: unexpected error when fetching entities from Catalyst

### DIFF
--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -14,55 +14,67 @@ export function createDeployerComponent(
   return {
     async deployEntity(entity, servers) {
       const markAsDeployed = entity.markAsDeployed ? entity.markAsDeployed : async () => {}
-      if (entity.entityType === 'scene' || entity.entityType === 'wearable' || entity.entityType === 'emote') {
-        const exists = await components.storage.exist(entity.entityId)
+      try {
+        if (entity.entityType === 'scene' || entity.entityType === 'wearable' || entity.entityType === 'emote') {
+          const exists = await components.storage.exist(entity.entityId)
 
-        if (!exists) {
-          await components.downloadQueue.onSizeLessThan(1000)
+          if (!exists) {
+            await components.downloadQueue.onSizeLessThan(1000)
 
-          void components.downloadQueue.scheduleJob(async () => {
-            logger.info('Downloading entity', {
-              entityId: entity.entityId,
-              entityType: entity.entityType,
-              servers: servers.join(',')
-            })
-
-            await downloadEntityAndContentFiles(
-              { ...components, fetcher: components.fetch },
-              entity.entityId,
-              servers,
-              new Map(),
-              'content',
-              10,
-              1000
-            )
-
-            logger.info('Entity stored', { entityId: entity.entityId, entityType: entity.entityType })
-
-            // send sns
-            if (components.sns.arn) {
-              const deploymentToSqs: DeploymentToSqs = {
-                entity,
-                contentServerUrls: servers
-              }
-              const receipt = await sns
-                .publish({
-                  TopicArn: components.sns.arn,
-                  Message: JSON.stringify(deploymentToSqs)
-                })
-                .promise()
-              logger.info('Notification sent', {
-                MessageId: receipt.MessageId as any,
-                SequenceNumber: receipt.SequenceNumber as any
+            void components.downloadQueue.scheduleJob(async () => {
+              logger.info('Downloading entity', {
+                entityId: entity.entityId,
+                entityType: entity.entityType,
+                servers: servers.join(',')
               })
-            }
+
+              await downloadEntityAndContentFiles(
+                { ...components, fetcher: components.fetch },
+                entity.entityId,
+                servers,
+                new Map(),
+                'content',
+                10,
+                1000
+              )
+
+              logger.info('Entity stored', { entityId: entity.entityId, entityType: entity.entityType })
+
+              // send sns
+              if (components.sns.arn) {
+                const deploymentToSqs: DeploymentToSqs = {
+                  entity,
+                  contentServerUrls: servers
+                }
+                const receipt = await sns
+                  .publish({
+                    TopicArn: components.sns.arn,
+                    Message: JSON.stringify(deploymentToSqs)
+                  })
+                  .promise()
+                logger.info('Notification sent', {
+                  MessageId: receipt.MessageId as any,
+                  SequenceNumber: receipt.SequenceNumber as any
+                })
+              }
+              await markAsDeployed()
+            })
+          } else {
             await markAsDeployed()
-          })
+          }
         } else {
           await markAsDeployed()
         }
-      } else {
-        await markAsDeployed()
+      } catch (error: any) {
+        const isNotRetryable = /status: 4\d{2}/.test(error.message)
+        if (isNotRetryable) {
+          logger.error('Failed to download entity', {
+            entityId: entity.entityId,
+            entityType: entity.entityType,
+            error: error?.message
+          })
+          await markAsDeployed()
+        }
       }
     },
     async onIdle() {}


### PR DESCRIPTION
When fetching entities from Catalyst, the request can fail with 4xx or 5xx errors. 4xx errors should not be retryable, whereas 5xx errors should be retried. This PR adds a try/catch block that captures these unhandled errors and analyzes whether the message should be deleted to avoid retries.

Error example:
`Error: Invalid response from https://peer.decentraland.org/content/contents/bafkreif7cpn7cek3yvhhnqulysujoxvarfo7jctc274j47ztjtfxftx7fu status: 404`