### PR TITLE
feat: also publish to old SNS a message with attributes for ABRegistry integration

### DIFF
--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -85,7 +85,11 @@ export function createDeployerComponent(
             const receipt = await client.send(
               new PublishCommand({
                 TopicArn: components.sns.arn,
-                Message: JSON.stringify(deploymentToSqs)
+                Message: JSON.stringify(deploymentToSqs),
+                MessageAttributes: {
+                  type: { DataType: 'String', StringValue: Events.Type.CATALYST_DEPLOYMENT },
+                  subType: { DataType: 'String', StringValue: entity.entityType as Events.SubType.CatalystDeployment }
+                }
               })
             )
             logger.info('Notification sent', {


### PR DESCRIPTION
This PR makes `deployments-to-sqs` publish events to old SNS topic with aggregated message attributes for futrher filtering at infrastructure/definitions level/