### PR TITLE
feat: prioritize organic deployments by adding priority message attribute

### DIFF
--- a/src/adapters/sns/publisher.ts
+++ b/src/adapters/sns/publisher.ts
@@ -41,7 +41,8 @@ async function createSnsPublisherComponent(
             Message: JSON.stringify(message),
             MessageAttributes: {
               type: { DataType: 'String', StringValue: Events.Type.CATALYST_DEPLOYMENT },
-              subType: { DataType: 'String', StringValue: entity.entityType as Events.SubType.CatalystDeployment }
+              subType: { DataType: 'String', StringValue: entity.entityType as Events.SubType.CatalystDeployment },
+              priority: { DataType: 'String', StringValue: 'Enabled' }
             }
           })
         )


### PR DESCRIPTION
This PR modifies how deployments are broadcasted through SNS. It introduces a new message attribute called `priority`, which ensures SNS sends messages to the priority Asset Bundle queues.

The goal of this PR is to always prioritize Catalyst deployments over reprocessing messages.