### PR TITLE
feat: add new attribute to SNS event to identify multiplayer scenes

### DIFF
--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -16,7 +16,7 @@ export function createDeployerComponent(
 ): IDeployerComponent {
   const logger = components.logs.getLogger('Deployer')
 
-  async function publishDeploymentNotifications(entity: DeployableEntity, servers: string[]) {
+  async function publishDeploymentNotifications(entity: DeployableEntity & { metadata: any }, servers: string[]) {
     const { snsPublisher, snsEventPublisher } = components
 
     const shouldSendEntityToSns = ['scene', 'wearable', 'emote'].includes(entity.entityType)
@@ -59,9 +59,9 @@ export function createDeployerComponent(
 
         void components.downloadQueue.scheduleJob(async () => {
           try {
-            await components.entityDownloader.downloadEntity(entity, servers)
+            const metadata = await components.entityDownloader.downloadEntity(entity, servers)
 
-            await publishDeploymentNotifications(entity, servers)
+            await publishDeploymentNotifications({ ...entity, metadata }, servers)
 
             await markAsDeployed()
 

--- a/src/adapters/sns/publisher.ts
+++ b/src/adapters/sns/publisher.ts
@@ -35,7 +35,7 @@ async function createSnsPublisherComponent(
           entityType: entity.entityType
         })
 
-        const isMultiplayerScene = entity.entityType === 'scene' && !!entity.metadata.multiplayerId
+        const isMultiplayerScene = entity.entityType === 'scene' && !!entity.metadata?.multiplayerId
 
         const receipt = await client.send(
           new PublishCommand({

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type BaseComponents = {
 }
 
 export type SnsPublisherComponent = {
-  publishMessage: (entity: DeployableEntity, contentServerUrls: string[]) => Promise<void>
+  publishMessage: (entity: DeployableEntity & { metadata: any }, contentServerUrls: string[]) => Promise<void>
 }
 
 export type EntityDownloaderComponent = {

--- a/test/unit/adapters/entity-downloader.spec.ts
+++ b/test/unit/adapters/entity-downloader.spec.ts
@@ -33,14 +33,19 @@ describe('EntityDownloaderComponent', () => {
       markAsDeployed: jest.fn(),
       pointers: ['pointer1'],
       authChain: [],
-      entityTimestamp: Date.now()
+      entityTimestamp: Date.now(),
+      localTimestamp: Date.now()
     }
 
     mockServers = ['server1', 'server2']
   })
 
   it('should download entity successfully', async () => {
-    downloadEntityAndContentFilesMock.mockResolvedValueOnce(undefined)
+    downloadEntityAndContentFilesMock.mockResolvedValueOnce({
+      type: 'scene',
+      metadata: { test: 'metadata' },
+      content: []
+    })
 
     const downloader = await createEntityDownloaderComponent(components)
     await downloader.downloadEntity(mockEntity, mockServers)

--- a/test/unit/adapters/sns.spec.ts
+++ b/test/unit/adapters/sns.spec.ts
@@ -24,7 +24,7 @@ describe('SnsPublisherComponent', () => {
 
   let components: jest.Mocked<Pick<AppComponents, 'config' | 'logs' | 'metrics'>>
 
-  let mockEntity: DeployableEntity
+  let mockEntity: DeployableEntity & { metadata: any }
   let mockServers: string[]
 
   let mockClient: SNSClient
@@ -42,8 +42,12 @@ describe('SnsPublisherComponent', () => {
       markAsDeployed: jest.fn(),
       pointers: ['pointer1'],
       authChain: [],
-      entityTimestamp: Date.now()
-    }
+      entityTimestamp: Date.now(),
+      localTimestamp: Date.now(),
+      metadata: {
+        multiplayerId: null
+      }
+    } as DeployableEntity & { metadata: any }
 
     mockServers = ['server1', 'server2']
 
@@ -116,7 +120,8 @@ describe('SnsPublisherComponent', () => {
           MessageAttributes: {
             type: { DataType: 'String', StringValue: Events.Type.CATALYST_DEPLOYMENT },
             subType: { DataType: 'String', StringValue: mockEntity.entityType },
-            priority: { DataType: 'String', StringValue: '1' }
+            priority: { DataType: 'String', StringValue: '1' },
+            isMultiplayer: { DataType: 'String', StringValue: 'false' }
           }
         })
       })

--- a/test/unit/adapters/sns.spec.ts
+++ b/test/unit/adapters/sns.spec.ts
@@ -103,6 +103,78 @@ describe('SnsPublisherComponent', () => {
     expect(metricsMock.increment).toHaveBeenCalledWith('sns_publish_failure', { type: SnsType.DEPLOYMENT })
   })
 
+  describe('isMultiplayer attribute', () => {
+    it('should set isMultiplayer to true for scenes with multiplayerId', async () => {
+      const multiplayerEntity = {
+        ...mockEntity,
+        metadata: { multiplayerId: 'mp-room-123' }
+      }
+
+      mockClient.send = jest.fn().mockResolvedValueOnce({ MessageId: 'message-id' })
+      mockArnConfigImplementation('SNS_ARN', 'test-arn')
+
+      const publisher = await createSnsDeploymentPublisherComponent(components)
+      await publisher.publishMessage(multiplayerEntity, mockServers)
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageAttributes: expect.objectContaining({
+              isMultiplayer: { DataType: 'String', StringValue: 'true' }
+            })
+          })
+        })
+      )
+    })
+
+    it('should set isMultiplayer to false for non-scene entities', async () => {
+      const profileEntity = {
+        ...mockEntity,
+        entityType: 'profile',
+        metadata: { anyData: 'value' }
+      }
+
+      mockClient.send = jest.fn().mockResolvedValueOnce({ MessageId: 'message-id' })
+      mockArnConfigImplementation('SNS_ARN', 'test-arn')
+
+      const publisher = await createSnsDeploymentPublisherComponent(components)
+      await publisher.publishMessage(profileEntity, mockServers)
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageAttributes: expect.objectContaining({
+              isMultiplayer: { DataType: 'String', StringValue: 'false' }
+            })
+          })
+        })
+      )
+    })
+
+    it('should set isMultiplayer to false for scenes without multiplayerId', async () => {
+      const singlePlayerEntity = {
+        ...mockEntity,
+        metadata: { someOtherData: 'value' }
+      }
+
+      mockClient.send = jest.fn().mockResolvedValueOnce({ MessageId: 'message-id' })
+      mockArnConfigImplementation('EVENTS_SNS_ARN', 'test-arn')
+
+      const publisher = await createSnsEventPublisherComponent(components)
+      await publisher.publishMessage(singlePlayerEntity, mockServers)
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            MessageAttributes: expect.objectContaining({
+              isMultiplayer: { DataType: 'String', StringValue: 'false' }
+            })
+          })
+        })
+      )
+    })
+  })
+
   // Helper Functions
   function mockArnConfigImplementation(expectedKey: string, arn: string) {
     configMock.requireString.mockImplementationOnce((key: string) => {


### PR DESCRIPTION
This PR proposes to identify multiplayer scenes by SNS message attributes so they can be routed to specific multiplayer server listeners.