### PR TITLE
fix: stage storage streams to disk to survive S3 mid-download aborts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "devDependencies": {
     "@dcl/eslint-config": "^1.1.12",
-    "@types/node": "^14.17.33",
+    "@types/node": "^24.0.0",
     "@well-known-components/test-helpers": "^1.5.6",
-    "typescript": "^4.9.5"
+    "typescript": "^5.6.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/src/adapters/storage/index.ts
+++ b/src/adapters/storage/index.ts
@@ -112,12 +112,33 @@ export function createResilientContentStorage(
           const source = await item.asStream()
           const tmpPath = await stageToDisk(fileId, source)
 
-          // `fs.ReadStream` always emits 'close' after 'end' or 'error',
-          // so a single listener is enough to cover both paths.
           const readStream = createReadStream(tmpPath)
-          readStream.once('close', () => {
-            unlink(tmpPath).catch(() => {})
-          })
+
+          // `fs.ReadStream` emits 'close' after both 'end' and 'error', so
+          // 'close' alone is enough to cover the common paths. Listening on
+          // 'error' too is belt-and-suspenders in case future Node changes
+          // alter the ordering. `cleaned` guarantees the unlink runs once,
+          // so the second listener doesn't produce spurious ENOENT noise.
+          //
+          // Remaining assumption: the caller eventually reads or destroys
+          // the stream. If it's awaited and then dropped on the floor, the
+          // fd is never opened, 'close' never fires, and the temp file
+          // persists until the task restarts (Fargate wipes `/tmp` on
+          // restart). All current in-repo consumers iterate the stream or
+          // call `.destroy()` in a `finally` block.
+          let cleaned = false
+          const cleanup = (): void => {
+            if (cleaned) {
+              return
+            }
+            cleaned = true
+            unlink(tmpPath).catch((err: unknown) => {
+              const message = err instanceof Error ? err.message : String(err)
+              logger.warn('Failed to unlink staged content file', { tmpPath, error: message })
+            })
+          }
+          readStream.once('close', cleanup)
+          readStream.once('error', cleanup)
           return readStream
         }
       }

--- a/src/adapters/storage/index.ts
+++ b/src/adapters/storage/index.ts
@@ -8,6 +8,13 @@ import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
 import { AppComponents } from '../../types'
 
+// Upper bound on how long `stageToDisk` is allowed to run before we give up
+// on the underlying stream. Guards against a source that stays alive but
+// stops producing data (e.g. S3 throttling without a FIN) — without it,
+// `pipeline()` would wait forever. Generous enough for realistic snapshot
+// sizes; if it fires, snapshot-fetcher's retry layer will re-attempt.
+const STAGE_TIMEOUT_MS = 10 * 60 * 1000
+
 /**
  * Wraps an `IContentStorageComponent` so that streams returned by `retrieve()`
  * are first staged to an ephemeral file on local disk before being handed
@@ -43,31 +50,38 @@ export function createResilientContentStorage(
    *
    * Uses `pipeline()` so any error on `source` (e.g. S3 abort) or on the
    * write stream (e.g. disk full) propagates as a rejected promise and
-   * both streams are destroyed. On failure the partial file is removed;
-   * cleanup errors are swallowed on purpose so the original error surfaces.
+   * both streams are destroyed. A timeout signal prevents the call from
+   * hanging forever on a stalled-but-alive source. On any failure the
+   * partial file is removed; cleanup errors are swallowed on purpose so
+   * the original error surfaces.
    *
    * @param fileId - Logical id of the content being staged (for logging).
    * @param source - Readable whose body should be staged.
    * @returns Absolute path to the staged temp file.
-   * @throws Propagates any error from the source or the write stream.
+   * @throws Propagates any error from the source, the write stream, or the
+   *         timeout signal (as an `AbortError`).
    */
   async function stageToDisk(fileId: string, source: Readable): Promise<string> {
     const tmpPath = join(tmpdir(), `content-stage-${randomUUID()}`)
     try {
-      await pipeline(source, createWriteStream(tmpPath))
+      await pipeline(source, createWriteStream(tmpPath), { signal: AbortSignal.timeout(STAGE_TIMEOUT_MS) })
       return tmpPath
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
       logger.warn('Failed while staging content stream to disk', {
         fileId,
-        error: error?.message || 'unknown error'
+        error: message
       })
       await unlink(tmpPath).catch(() => {})
       throw error
     }
   }
 
-  // Forward every non-retrieve method unchanged. `bind` preserves `this`
-  // for implementations that rely on it internally.
+  // Forward every non-retrieve method explicitly. `bind` preserves `this`
+  // for implementations that rely on it internally. A `{ ...inner }` spread
+  // would auto-forward future members but drop the `this` binding — we
+  // prefer the explicit list, and TypeScript will fail the build if
+  // `IContentStorageComponent` grows a required method.
   return {
     storeStream: inner.storeStream.bind(inner),
     storeStreamAndCompress: inner.storeStreamAndCompress.bind(inner),
@@ -87,6 +101,12 @@ export function createResilientContentStorage(
       return {
         encoding: item.encoding,
         size: item.size,
+        // `asRawStream` is intentionally forwarded unwrapped. It returns the
+        // raw (potentially compressed) S3 body and is not used by any code
+        // path in this repo; snapshot-fetcher only calls `asStream`. If a
+        // future consumer starts relying on `asRawStream` with a slow
+        // reader, the same abort vulnerability will resurface and this
+        // method should be wrapped too.
         asRawStream: item.asRawStream.bind(item),
         async asStream(): Promise<Readable> {
           const source = await item.asStream()

--- a/src/adapters/storage/index.ts
+++ b/src/adapters/storage/index.ts
@@ -1,0 +1,106 @@
+import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { randomUUID } from 'crypto'
+import { createReadStream, createWriteStream } from 'fs'
+import { unlink } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import { AppComponents } from '../../types'
+
+/**
+ * Wraps an `IContentStorageComponent` so that streams returned by `retrieve()`
+ * are first staged to an ephemeral file on local disk before being handed
+ * back to the caller.
+ *
+ * The underlying S3 client (aws-sdk v2, pulled in by `@dcl/catalyst-storage`)
+ * emits `error: aborted` on the response stream when a connection drops
+ * mid-download — for example when the consumer (`readline` inside
+ * `@dcl/snapshots-fetcher`) idles the socket past S3's idle timeout while
+ * the deployer's download queue is saturated. That error is re-emitted on
+ * the `readline` Interface which has no listener, becoming an uncaught
+ * exception that kills the process.
+ *
+ * Staging the body to disk decouples the S3 socket from the line-by-line
+ * consumer: the drain runs at full speed into a local file, so the S3
+ * connection can't idle out. A mid-download abort rejects `asStream()`
+ * before any consumer sees it, letting snapshot-fetcher's retry layer
+ * handle it.
+ *
+ * @param components - Well-Known Components dependencies (logger only).
+ * @param inner - The storage component to wrap. All non-`retrieve` methods
+ *                are forwarded unchanged.
+ * @returns An `IContentStorageComponent` with disk-staged retrieval.
+ */
+export function createResilientContentStorage(
+  components: Pick<AppComponents, 'logs'>,
+  inner: IContentStorageComponent
+): IContentStorageComponent {
+  const logger = components.logs.getLogger('ResilientContentStorage')
+
+  /**
+   * Drains `source` into a freshly-named temp file and returns its path.
+   *
+   * Uses `pipeline()` so any error on `source` (e.g. S3 abort) or on the
+   * write stream (e.g. disk full) propagates as a rejected promise and
+   * both streams are destroyed. On failure the partial file is removed;
+   * cleanup errors are swallowed on purpose so the original error surfaces.
+   *
+   * @param fileId - Logical id of the content being staged (for logging).
+   * @param source - Readable whose body should be staged.
+   * @returns Absolute path to the staged temp file.
+   * @throws Propagates any error from the source or the write stream.
+   */
+  async function stageToDisk(fileId: string, source: Readable): Promise<string> {
+    const tmpPath = join(tmpdir(), `content-stage-${randomUUID()}`)
+    try {
+      await pipeline(source, createWriteStream(tmpPath))
+      return tmpPath
+    } catch (error: any) {
+      logger.warn('Failed while staging content stream to disk', {
+        fileId,
+        error: error?.message || 'unknown error'
+      })
+      await unlink(tmpPath).catch(() => {})
+      throw error
+    }
+  }
+
+  // Forward every non-retrieve method unchanged. `bind` preserves `this`
+  // for implementations that rely on it internally.
+  return {
+    storeStream: inner.storeStream.bind(inner),
+    storeStreamAndCompress: inner.storeStreamAndCompress.bind(inner),
+    delete: inner.delete.bind(inner),
+    fileInfo: inner.fileInfo.bind(inner),
+    fileInfoMultiple: inner.fileInfoMultiple.bind(inner),
+    exist: inner.exist.bind(inner),
+    existMultiple: inner.existMultiple.bind(inner),
+    allFileIds: inner.allFileIds.bind(inner),
+
+    async retrieve(fileId: string): Promise<ContentItem | undefined> {
+      const item = await inner.retrieve(fileId)
+      if (!item) {
+        return item
+      }
+
+      return {
+        encoding: item.encoding,
+        size: item.size,
+        asRawStream: item.asRawStream.bind(item),
+        async asStream(): Promise<Readable> {
+          const source = await item.asStream()
+          const tmpPath = await stageToDisk(fileId, source)
+
+          // `fs.ReadStream` always emits 'close' after 'end' or 'error',
+          // so a single listener is enough to cover both paths.
+          const readStream = createReadStream(tmpPath)
+          readStream.once('close', () => {
+            unlink(tmpPath).catch(() => {})
+          })
+          return readStream
+        }
+      }
+    }
+  }
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -17,6 +17,7 @@ import {
 import { Readable } from 'stream'
 import { createEntityDownloaderComponent } from './adapters/entity-downloader'
 import { createSnsDeploymentPublisherComponent, createSnsEventPublisherComponent } from './adapters/sns'
+import { createResilientContentStorage } from './adapters/storage'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -36,9 +37,11 @@ export async function initComponents(): Promise<AppComponents> {
 
   const bucket = await config.getString('BUCKET')
 
-  const storage = bucket
+  const rawStorage = bucket
     ? await createAwsS3BasedFileSystemContentStorage({ config, logs }, bucket)
     : await createFolderBasedFileSystemContentStorage({ fs, logs }, downloadsFolder)
+
+  const storage = createResilientContentStorage({ logs }, rawStorage)
 
   const downloadQueue = createJobQueue({
     autoStart: true,

--- a/test/unit/adapters/storage.spec.ts
+++ b/test/unit/adapters/storage.spec.ts
@@ -1,9 +1,12 @@
 import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
 import { readdirSync } from 'fs'
 import { tmpdir } from 'os'
-import { Readable } from 'stream'
+import { Readable, Writable } from 'stream'
 import { createResilientContentStorage } from '../../../src/adapters/storage'
 import { logsMock, storageMock } from '../../mocks/components'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs') as typeof import('fs')
 
 const STAGING_PREFIX = 'content-stage-'
 
@@ -25,12 +28,25 @@ describe('ResilientContentStorage', () => {
   let innerStorage: jest.Mocked<IContentStorageComponent>
 
   beforeEach(() => {
+    // `resetAllMocks` in afterEach also drops implementations set at module
+    // load time (e.g. `logsMock.getLogger`'s return value), so we re-seed
+    // the logger mock on every test.
+    logsMock.getLogger.mockReturnValue({
+      log: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn()
+    })
     innerStorage = storageMock
     storage = createResilientContentStorage({ logs: logsMock }, innerStorage)
   })
 
   afterEach(async () => {
-    jest.clearAllMocks()
+    // `resetAllMocks` (vs `clearAllMocks`) also drops queued
+    // `mockResolvedValueOnce` implementations, so no state leaks into
+    // subsequent tests that share `storageMock`.
+    jest.resetAllMocks()
     await waitForNoStagingFiles()
   })
 
@@ -81,6 +97,40 @@ describe('ResilientContentStorage', () => {
 
         await waitForNoStagingFiles()
         expect(listStagingFiles().length).toBe(stagingFilesBefore)
+      })
+    })
+
+    describe('and the local write stream fails (e.g. disk full)', () => {
+      let innerItem: ContentItem
+      let sourceStream: Readable
+      let createWriteStreamSpy: jest.SpyInstance
+
+      beforeEach(() => {
+        sourceStream = Readable.from(Buffer.from('some content'))
+
+        const failingWrite = new Writable({
+          write(_chunk, _encoding, callback) {
+            callback(Object.assign(new Error('disk full'), { code: 'ENOSPC' }))
+          }
+        })
+        createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockReturnValueOnce(failingWrite as any)
+
+        innerItem = {
+          encoding: null,
+          size: 12,
+          asStream: jest.fn().mockResolvedValue(sourceStream),
+          asRawStream: jest.fn()
+        }
+        innerStorage.retrieve.mockResolvedValueOnce(innerItem)
+      })
+
+      afterEach(() => {
+        createWriteStreamSpy.mockRestore()
+      })
+
+      it('should reject asStream with the write-side error', async () => {
+        const item = await storage.retrieve('disk-full')
+        await expect(item!.asStream()).rejects.toThrow('disk full')
       })
     })
 

--- a/test/unit/adapters/storage.spec.ts
+++ b/test/unit/adapters/storage.spec.ts
@@ -1,0 +1,137 @@
+import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { readdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { Readable } from 'stream'
+import { createResilientContentStorage } from '../../../src/adapters/storage'
+import { logsMock, storageMock } from '../../mocks/components'
+
+const STAGING_PREFIX = 'content-stage-'
+
+function listStagingFiles(): string[] {
+  return readdirSync(tmpdir()).filter((name) => name.startsWith(STAGING_PREFIX))
+}
+
+async function waitForNoStagingFiles(): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (listStagingFiles().length === 0) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+describe('ResilientContentStorage', () => {
+  let storage: IContentStorageComponent
+  let innerStorage: jest.Mocked<IContentStorageComponent>
+
+  beforeEach(() => {
+    innerStorage = storageMock
+    storage = createResilientContentStorage({ logs: logsMock }, innerStorage)
+  })
+
+  afterEach(async () => {
+    jest.clearAllMocks()
+    await waitForNoStagingFiles()
+  })
+
+  describe('when retrieving a file that does not exist', () => {
+    beforeEach(() => {
+      innerStorage.retrieve.mockResolvedValueOnce(undefined)
+    })
+
+    it('should return undefined', async () => {
+      await expect(storage.retrieve('missing')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('when retrieving a file that exists', () => {
+    describe('and the stream completes successfully', () => {
+      let innerItem: ContentItem
+
+      beforeEach(() => {
+        innerItem = {
+          encoding: null,
+          size: 11,
+          asStream: jest.fn().mockResolvedValue(Readable.from(Buffer.from('hello world'))),
+          asRawStream: jest.fn()
+        }
+        innerStorage.retrieve.mockResolvedValueOnce(innerItem)
+      })
+
+      it('should return a read stream whose contents match the original body', async () => {
+        const item = await storage.retrieve('ok')
+        const stream = await item!.asStream()
+
+        const chunks: Buffer[] = []
+        for await (const chunk of stream) {
+          chunks.push(chunk as Buffer)
+        }
+
+        expect(Buffer.concat(chunks).toString()).toBe('hello world')
+      })
+
+      it('should delete the staged file after the read stream closes', async () => {
+        const stagingFilesBefore = listStagingFiles().length
+        const item = await storage.retrieve('ok')
+        const stream = await item!.asStream()
+
+        for await (const _chunk of stream) {
+          // drain
+        }
+
+        await waitForNoStagingFiles()
+        expect(listStagingFiles().length).toBe(stagingFilesBefore)
+      })
+    })
+
+    describe('and the underlying stream aborts mid-download', () => {
+      let innerItem: ContentItem
+      let erroringStream: Readable
+
+      beforeEach(() => {
+        let emittedPartial = false
+        erroringStream = new Readable({
+          read() {
+            if (!emittedPartial) {
+              emittedPartial = true
+              this.push(Buffer.from('partial'))
+              process.nextTick(() => this.destroy(new Error('aborted')))
+            }
+          }
+        })
+        innerItem = {
+          encoding: null,
+          size: 100,
+          asStream: jest.fn().mockResolvedValue(erroringStream),
+          asRawStream: jest.fn()
+        }
+        innerStorage.retrieve.mockResolvedValueOnce(innerItem)
+      })
+
+      it('should reject asStream with the underlying error instead of emitting it on the returned stream', async () => {
+        const item = await storage.retrieve('aborted-file')
+        await expect(item!.asStream()).rejects.toThrow('aborted')
+      })
+
+      it('should not leak the staged file after the abort', async () => {
+        const stagingFilesBefore = listStagingFiles().length
+        const item = await storage.retrieve('aborted-file')
+        await expect(item!.asStream()).rejects.toThrow('aborted')
+
+        await waitForNoStagingFiles()
+        expect(listStagingFiles().length).toBe(stagingFilesBefore)
+      })
+    })
+  })
+
+  describe('when calling non-retrieve methods', () => {
+    beforeEach(() => {
+      innerStorage.exist.mockResolvedValueOnce(true)
+    })
+
+    it('should forward the call to the inner storage', async () => {
+      await expect(storage.exist('some-id')).resolves.toBe(true)
+      expect(innerStorage.exist).toHaveBeenCalledWith('some-id')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,17 +1726,19 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@^14.17.33":
-  version "14.18.63"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
-
 "@types/node@^20.3.1":
   version "20.17.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.10.tgz#3f7166190aece19a0d1d364d75c8b0b5778c1e18"
   integrity sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==
   dependencies:
     undici-types "~6.19.2"
+
+"@types/node@^24.0.0":
+  version "24.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
+  integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/qs@*":
   version "6.9.10"
@@ -5040,10 +5042,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.6.0:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undici-types@~6.19.2:
   version "6.19.8"
@@ -5054,6 +5056,11 @@ undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

- Prevents server crashes seen during catalyst re-syncs where the process dies with `Uncaught Error: aborted` originating from `aws-sdk/lib/request.js` inside a `readline.Interface` frame.
- Introduces `createResilientContentStorage`, a thin wrapper around `IContentStorageComponent` that stages every `retrieve().asStream()` to a local temp file before returning the readable.
- Bumps `@types/node` and `typescript` to the Node 24 LTS line.

## Why the crash happens

During re-sync, `@dcl/snapshots-fetcher` streams the snapshot file directly from S3 and iterates it line-by-line with `readline`. For each line it calls `deployer.scheduleEntityDeployment`, which awaits `downloadQueue.onSizeLessThan(1000)`.

Under heavy load the queue saturates and iteration pauses on that await. While paused, the S3 GET socket backing the snapshot stream sits idle; AWS closes it after its idle timeout and the aws-sdk v2 ``IncomingMessage`` emits `error: aborted`. readline re-emits that error on its ``Interface`` which has no ``error`` listener at that point, producing an uncaught exception that kills the process under ``--abort-on-uncaught-exception``.

## The fix

`retrieve().asStream()` now ``pipeline()``s the body into ``os.tmpdir()/content-stage-<uuid>`` and returns a ``fs.createReadStream`` of that local file. Because the drain runs at full speed (disk is never the bottleneck), the S3 socket cannot idle out. A mid-download abort rejects ``asStream()`` which bubbles into snapshot-fetcher's ``createExponentialFallofRetry`` and is retried cleanly. The temp file is unlinked on the read stream's ``close`` event; on failure the partial file is unlinked before the error propagates.

Fargate-specific implications:
- Temp files live on the task's ephemeral volume (20 GiB default). Largest snapshot × concurrent streams must fit; bump task ephemeral storage in the task definition if that becomes tight.
- No orphan-cleanup cron needed — Fargate wipes ``/tmp`` on container restart.

## Test plan

- [x] ``yarn build`` passes on Node 24 types + TS 5.6.
- [x] ``yarn lint:check`` passes.
- [x] ``yarn jest test/unit`` — 26/26 pass including 6 new tests in ``test/unit/adapters/storage.spec.ts`` covering: missing file, successful drain + tmp cleanup, mid-download abort rejecting ``asStream()``, no tmp-file leak on abort, and non-``retrieve`` method forwarding.
- [ ] Deploy to stg and verify no ``Uncaught Error: aborted`` lines during a triggered catalyst re-sync.
- [ ] Monitor ``schedule_entity_deployment_attempt`` / ``entity_deployment_success`` metrics and ephemeral-storage usage on the task during re-sync.