### PR TITLE
feat: skip entities older than configurable max age

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -22,3 +22,7 @@ HTTP_SERVER_PORT=3000
 HTTP_SERVER_HOST=0.0.0.0
 # Comma-separated list of Catalyst content server URLs to monitor
 CONTENT_SERVER_URLS=
+# Maximum age of an entity (in seconds) to process. Entities older than this are skipped entirely
+# (no download, no SNS publish). Useful during catalyst reprocessing to drain the backlog without
+# propagating old events downstream. Disabled when unset, 0, or non-numeric.
+ENTITY_MAX_AGE_IN_SECONDS=

--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -1,9 +1,10 @@
 import { DeployableEntity, IDeployerComponent, TimeRange } from '@dcl/snapshots-fetcher/dist/types'
 import { AppComponents, EntityDownloadError, SnsPublisherComponent } from '../../types'
 
-export function createDeployerComponent(
+export async function createDeployerComponent(
   components: Pick<
     AppComponents,
+    | 'config'
     | 'logs'
     | 'storage'
     | 'downloadQueue'
@@ -13,8 +14,11 @@ export function createDeployerComponent(
     | 'snsEventPublisher'
     | 'entityDownloader'
   >
-): IDeployerComponent {
+): Promise<IDeployerComponent> {
   const logger = components.logs.getLogger('Deployer')
+
+  const maxAgeInSeconds = parseInt((await components.config.getString('ENTITY_MAX_AGE_IN_SECONDS')) ?? '0')
+  const filterEnabled = !isNaN(maxAgeInSeconds) && maxAgeInSeconds > 0
 
   async function publishDeploymentNotifications(entity: DeployableEntity & { metadata: any }, servers: string[]) {
     const { snsPublisher, snsEventPublisher } = components
@@ -40,6 +44,20 @@ export function createDeployerComponent(
       components.metrics.increment('schedule_entity_deployment_attempt', {
         entityType: entity.entityType
       })
+
+      if (filterEnabled) {
+        const entityAgeInSeconds = (Date.now() - entity.entityTimestamp) / 1000
+        if (entityAgeInSeconds > maxAgeInSeconds) {
+          logger.debug('Skipping old entity', {
+            entityId: entity.entityId,
+            entityType: entity.entityType,
+            entityAgeInSeconds,
+            maxAgeInSeconds
+          })
+          components.metrics.increment('entity_skipped_old', { entityType: entity.entityType })
+          return await markAsDeployed()
+        }
+      }
 
       try {
         const exists = await components.storage.exist(entity.entityId)

--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -17,8 +17,13 @@ export async function createDeployerComponent(
 ): Promise<IDeployerComponent> {
   const logger = components.logs.getLogger('Deployer')
 
-  const maxAgeInSeconds = parseInt((await components.config.getString('ENTITY_MAX_AGE_IN_SECONDS')) ?? '0')
-  const filterEnabled = !isNaN(maxAgeInSeconds) && maxAgeInSeconds > 0
+  const maxAgeInSeconds = parseInt((await components.config.getString('ENTITY_MAX_AGE_IN_SECONDS')) ?? '', 10)
+
+  if (maxAgeInSeconds > 0) {
+    logger.info('Entity age filter enabled', { maxAgeInSeconds })
+  } else {
+    logger.info('Entity age filter disabled')
+  }
 
   async function publishDeploymentNotifications(entity: DeployableEntity & { metadata: any }, servers: string[]) {
     const { snsPublisher, snsEventPublisher } = components
@@ -45,21 +50,21 @@ export async function createDeployerComponent(
         entityType: entity.entityType
       })
 
-      if (filterEnabled) {
-        const entityAgeInSeconds = (Date.now() - entity.entityTimestamp) / 1000
-        if (entityAgeInSeconds > maxAgeInSeconds) {
-          logger.debug('Skipping old entity', {
-            entityId: entity.entityId,
-            entityType: entity.entityType,
-            entityAgeInSeconds,
-            maxAgeInSeconds
-          })
-          components.metrics.increment('entity_skipped_old', { entityType: entity.entityType })
-          return await markAsDeployed()
-        }
-      }
-
       try {
+        if (maxAgeInSeconds > 0) {
+          const entityAgeInSeconds = (Date.now() - entity.entityTimestamp) / 1000
+          if (entityAgeInSeconds > maxAgeInSeconds) {
+            logger.debug('Skipping old entity', {
+              entityId: entity.entityId,
+              entityType: entity.entityType,
+              entityAgeInSeconds,
+              maxAgeInSeconds
+            })
+            components.metrics.increment('entity_skipped_old', { entityType: entity.entityType })
+            return await markAsDeployed()
+          }
+        }
+
         const exists = await components.storage.exist(entity.entityId)
 
         if (exists) {

--- a/src/components.ts
+++ b/src/components.ts
@@ -54,7 +54,8 @@ export async function initComponents(): Promise<AppComponents> {
 
   const entityDownloader = await createEntityDownloaderComponent({ config, logs, storage, fetch, metrics })
 
-  const deployer = createDeployerComponent({
+  const deployer = await createDeployerComponent({
+    config,
     storage,
     downloadQueue,
     fetch,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -51,6 +51,11 @@ export const metricDeclarations = {
     help: 'Count failed entity deployments',
     type: IMetricsComponent.CounterType,
     labelNames: ['entityType', 'retryable']
+  },
+  entity_skipped_old: {
+    help: 'Count entities skipped because they are older than the configured max age',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['entityType']
   }
 }
 

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -1,6 +1,7 @@
 import { AppComponents } from '../../../src/types'
 import { createDeployerComponent } from '../../../src/adapters/deployer'
 import {
+  configMock,
   logsMock,
   storageMock,
   fetcherMock,
@@ -15,6 +16,7 @@ describe('DeployerComponent', () => {
   let components: jest.Mocked<
     Pick<
       AppComponents,
+      | 'config'
       | 'logs'
       | 'storage'
       | 'downloadQueue'
@@ -32,8 +34,10 @@ describe('DeployerComponent', () => {
   beforeEach(() => {
     downloadQueueMock.onSizeLessThan.mockResolvedValue()
     downloadQueueMock.scheduleJob.mockImplementation(async (fn) => await fn())
+    configMock.getString.mockResolvedValue('')
 
     components = {
+      config: configMock,
       logs: logsMock,
       storage: storageMock,
       downloadQueue: downloadQueueMock,
@@ -65,7 +69,7 @@ describe('DeployerComponent', () => {
   it('should call mark as deployed when the entity is already stored', async () => {
     storageMock.exist.mockResolvedValue(true)
 
-    const deployer = createDeployerComponent(components)
+    const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_already_stored', {
@@ -81,7 +85,7 @@ describe('DeployerComponent', () => {
 
     const mockEntityWithoutMarkAsDeployed = { ...mockEntity, markAsDeployed: undefined }
 
-    const deployer = createDeployerComponent(components)
+    const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntityWithoutMarkAsDeployed, mockServers)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_already_stored', {
@@ -96,7 +100,7 @@ describe('DeployerComponent', () => {
     entityDownloaderMock.downloadEntity.mockResolvedValue()
     snsPublisherMock.publishMessage.mockResolvedValue()
 
-    const deployer = createDeployerComponent(components)
+    const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
 
     await jest.advanceTimersByTimeAsync(0)
@@ -118,7 +122,7 @@ describe('DeployerComponent', () => {
     storageMock.exist.mockResolvedValue(false)
     entityDownloaderMock.downloadEntity.mockRejectedValue(new Error('Network Error'))
 
-    const deployer = createDeployerComponent(components)
+    const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
@@ -132,7 +136,7 @@ describe('DeployerComponent', () => {
     storageMock.exist.mockResolvedValue(false)
     entityDownloaderMock.downloadEntity.mockRejectedValue(new Error('status: 404'))
 
-    const deployer = createDeployerComponent(components)
+    const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
@@ -146,12 +150,66 @@ describe('DeployerComponent', () => {
     storageMock.exist.mockResolvedValue(false)
     downloadQueueMock.onSizeLessThan.mockRejectedValue(new Error('Queue Error'))
 
-    const deployer = createDeployerComponent(components)
+    const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
       entityType: mockEntity.entityType
     })
     expect(mockEntity.markAsDeployed).not.toHaveBeenCalled()
+  })
+
+  describe('entity age filter', () => {
+    it('should skip and mark as deployed entities older than the configured max age', async () => {
+      const maxAgeInSeconds = 3600
+      configMock.getString.mockResolvedValue(String(maxAgeInSeconds))
+      const oldTimestamp = Date.now() - (maxAgeInSeconds + 1) * 1000
+      const oldEntity = { ...mockEntity, entityTimestamp: oldTimestamp }
+
+      const deployer = await createDeployerComponent(components)
+      await deployer.scheduleEntityDeployment(oldEntity, mockServers)
+
+      expect(metricsMock.increment).toHaveBeenCalledWith('entity_skipped_old', {
+        entityType: oldEntity.entityType
+      })
+      expect(oldEntity.markAsDeployed).toHaveBeenCalled()
+      expect(storageMock.exist).not.toHaveBeenCalled()
+      expect(downloadQueueMock.onSizeLessThan).not.toHaveBeenCalled()
+      expect(entityDownloaderMock.downloadEntity).not.toHaveBeenCalled()
+    })
+
+    it('should process recent entities normally when the age filter is enabled', async () => {
+      const maxAgeInSeconds = 3600
+      configMock.getString.mockResolvedValue(String(maxAgeInSeconds))
+      storageMock.exist.mockResolvedValue(false)
+      entityDownloaderMock.downloadEntity.mockResolvedValue()
+      snsPublisherMock.publishMessage.mockResolvedValue()
+
+      const deployer = await createDeployerComponent(components)
+      await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+
+      await jest.advanceTimersByTimeAsync(0)
+
+      expect(metricsMock.increment).not.toHaveBeenCalledWith('entity_skipped_old', expect.anything())
+      expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(mockEntity, mockServers)
+      expect(mockEntity.markAsDeployed).toHaveBeenCalled()
+    })
+
+    it('should process all entities when the age filter is disabled', async () => {
+      configMock.getString.mockResolvedValue('')
+      storageMock.exist.mockResolvedValue(false)
+      entityDownloaderMock.downloadEntity.mockResolvedValue()
+      snsPublisherMock.publishMessage.mockResolvedValue()
+      const oldTimestamp = Date.now() - 10 * 365 * 24 * 3600 * 1000
+      const oldEntity = { ...mockEntity, entityTimestamp: oldTimestamp }
+
+      const deployer = await createDeployerComponent(components)
+      await deployer.scheduleEntityDeployment(oldEntity, mockServers)
+
+      await jest.advanceTimersByTimeAsync(0)
+
+      expect(metricsMock.increment).not.toHaveBeenCalledWith('entity_skipped_old', expect.anything())
+      expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(oldEntity, mockServers)
+    })
   })
 })

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -213,21 +213,24 @@ describe('DeployerComponent', () => {
       expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(boundaryEntity, mockServers)
     })
 
-    it.each(['', '0', 'abc', '-3600'])('should process all entities when config is "%s" (filter disabled)', async (configValue) => {
-      configMock.getString.mockResolvedValue(configValue)
-      storageMock.exist.mockResolvedValue(false)
-      entityDownloaderMock.downloadEntity.mockResolvedValue()
-      snsPublisherMock.publishMessage.mockResolvedValue()
-      const oldTimestamp = Date.now() - 10 * 365 * 24 * 3600 * 1000
-      const oldEntity = { ...mockEntity, entityTimestamp: oldTimestamp }
+    it.each(['', '0', 'abc', '-3600'])(
+      'should process all entities when config is "%s" (filter disabled)',
+      async (configValue) => {
+        configMock.getString.mockResolvedValue(configValue)
+        storageMock.exist.mockResolvedValue(false)
+        entityDownloaderMock.downloadEntity.mockResolvedValue()
+        snsPublisherMock.publishMessage.mockResolvedValue()
+        const oldTimestamp = Date.now() - 10 * 365 * 24 * 3600 * 1000
+        const oldEntity = { ...mockEntity, entityTimestamp: oldTimestamp }
 
-      const deployer = await createDeployerComponent(components)
-      await deployer.scheduleEntityDeployment(oldEntity, mockServers)
+        const deployer = await createDeployerComponent(components)
+        await deployer.scheduleEntityDeployment(oldEntity, mockServers)
 
-      await jest.advanceTimersByTimeAsync(0)
+        await jest.advanceTimersByTimeAsync(0)
 
-      expect(metricsMock.increment).not.toHaveBeenCalledWith('entity_skipped_old', expect.anything())
-      expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(oldEntity, mockServers)
-    })
+        expect(metricsMock.increment).not.toHaveBeenCalledWith('entity_skipped_old', expect.anything())
+        expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(oldEntity, mockServers)
+      }
+    )
   })
 })

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -195,8 +195,26 @@ describe('DeployerComponent', () => {
       expect(mockEntity.markAsDeployed).toHaveBeenCalled()
     })
 
-    it('should process all entities when the age filter is disabled', async () => {
-      configMock.getString.mockResolvedValue('')
+    it('should not skip an entity aged exactly at the threshold', async () => {
+      const maxAgeInSeconds = 3600
+      configMock.getString.mockResolvedValue(String(maxAgeInSeconds))
+      storageMock.exist.mockResolvedValue(false)
+      entityDownloaderMock.downloadEntity.mockResolvedValue()
+      snsPublisherMock.publishMessage.mockResolvedValue()
+      const boundaryEntity = { ...mockEntity, entityTimestamp: Date.now() - maxAgeInSeconds * 1000 }
+
+      const deployer = await createDeployerComponent(components)
+      await deployer.scheduleEntityDeployment(boundaryEntity, mockServers)
+
+      await jest.advanceTimersByTimeAsync(0)
+
+      expect(metricsMock.increment).not.toHaveBeenCalledWith('entity_skipped_old', expect.anything())
+      expect(storageMock.exist).toHaveBeenCalled()
+      expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(boundaryEntity, mockServers)
+    })
+
+    it.each(['', '0', 'abc', '-3600'])('should process all entities when config is "%s" (filter disabled)', async (configValue) => {
+      configMock.getString.mockResolvedValue(configValue)
       storageMock.exist.mockResolvedValue(false)
       entityDownloaderMock.downloadEntity.mockResolvedValue()
       snsPublisherMock.publishMessage.mockResolvedValue()


### PR DESCRIPTION
## Summary

- Adds `ENTITY_MAX_AGE_IN_SECONDS` env var to filter out old entities at scheduling time, before any download or SNS publish happens
- During catalyst reprocessing, all historical entities are re-emitted — this filter prevents the resulting backlog from propagating to downstream consumers (Badges, Asset Bundle Converter, etc.)
- Solves the problem at the source instead of requiring each consumer to implement its own filter (cf. decentraland/badges#218)

## How it works

The check runs synchronously at the top of `scheduleEntityDeployment`, before the async `storage.exist()` call and any download:

```
Age check (sync) → skip + markAsDeployed if entity.entityTimestamp is too old
storage.exist()  → skip if already stored
downloadEntity() → HTTP calls to Catalyst
publishToSNS()   → SNS publish
```

When an entity is skipped, `markAsDeployed()` is called to prevent re-queueing, the `entity_skipped_old` metric is incremented, and a debug log is emitted.

The filter is **off by default** (unset / 0 / non-numeric = disabled), so existing deployments are unaffected.