### PR TITLE
fix: validate content servers and entity ids against a catalyst allowlist

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -22,6 +22,9 @@ HTTP_SERVER_PORT=3000
 HTTP_SERVER_HOST=0.0.0.0
 # Comma-separated list of Catalyst content server URLs to monitor
 CONTENT_SERVER_URLS=
+# SSRF allowlist (issue #306): comma-separated content-server hosts. Required —
+# CONTENT_SERVER_URLS must be a subset of these or the service won't boot.
+ALLOWED_CONTENT_SERVER_HOSTS=peer.decentraland.org,peer-ec1.decentraland.org,peer-ec2.decentraland.org,peer-wc1.decentraland.org,peer-eu1.decentraland.org,peer-ap1.decentraland.org,interconnected.online,peer.melonwave.com,peer.uadevops.com,peer.dclnodes.io,worlds-content-server.decentraland.org,peer-testing.decentraland.org,peer-testing-2.decentraland.org,peer.decentraland.zone,peer-ap1.decentraland.zone,worlds-content-server.decentraland.zone
 # Maximum age of an entity (in seconds) to process. Entities older than this are skipped entirely
 # (no download, no SNS publish). Useful during catalyst reprocessing to drain the backlog without
 # propagating old events downstream. Disabled when unset, 0, or non-numeric.

--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -1,5 +1,6 @@
 import { DeployableEntity, IDeployerComponent, TimeRange } from '@dcl/snapshots-fetcher/dist/types'
 import { AppComponents, EntityDownloadError, SnsPublisherComponent } from '../../types'
+import { isValidEntityId } from '../../logic/validation'
 
 export async function createDeployerComponent(
   components: Pick<
@@ -49,6 +50,19 @@ export async function createDeployerComponent(
       components.metrics.increment('schedule_entity_deployment_attempt', {
         entityType: entity.entityType
       })
+
+      // entityId comes from the (external) content server and flows into storage
+      // keys. A real entity id is a bare CID; reject anything with separators or
+      // `..` to prevent path traversal / S3-key injection. Drop it permanently
+      // (markAsDeployed) so snapshot-fetcher doesn't retry an unprocessable entity.
+      if (!isValidEntityId(entity.entityId)) {
+        logger.warn('Skipping entity: entityId is not a bare CID (path/key-injection guard)', {
+          entityId: String(entity.entityId).slice(0, 80),
+          entityType: entity.entityType
+        })
+        components.metrics.increment('entity_skipped_invalid_id', { entityType: entity.entityType })
+        return await markAsDeployed()
+      }
 
       try {
         if (maxAgeInSeconds > 0) {

--- a/src/logic/validation.ts
+++ b/src/logic/validation.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared security validations for the deployments pipeline. Mirrors the guards
+ * the asset-bundle-converter applies when it consumes our SQS messages
+ * (asset-bundle-converter issue #306): a strict catalyst host allowlist for the
+ * content-server URLs we sync from / publish, and a bare-CID check on the
+ * entityId before it is used as a storage key. Validating here too means a
+ * misconfigured content server fails fast at startup and a malformed entityId
+ * is dropped before it can reach the storage layer.
+ */
+
+/**
+ * Normalize one allowlist entry to a bare lowercase hostname. Accepts a bare
+ * host or a full URL (`https://peer…/content`) — the latter is tolerated because
+ * CONTENT_SERVER_URLS is itself a list of full URLs. Returns undefined for
+ * blank/unparseable entries so the caller can drop them.
+ */
+function normalizeContentServerHost(entry: string): string | undefined {
+  const trimmed = entry.trim().toLowerCase()
+  if (trimmed.length === 0) return undefined
+  if (trimmed.includes('/')) {
+    try {
+      const withScheme = /^[a-z][a-z0-9+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`
+      const host = new URL(withScheme).hostname.replace(/^\[|\]$/g, '').toLowerCase()
+      return host.length > 0 ? host : undefined
+    } catch {
+      return undefined
+    }
+  }
+  return trimmed
+}
+
+/**
+ * Parse the `ALLOWED_CONTENT_SERVER_HOSTS` env var (a comma-separated list of catalyst
+ * hosts) into a Set of normalized hostnames. There is no built-in fallback list:
+ * the allowlist is sourced entirely from config (set per-environment in the
+ * `definitions` repo); the caller requires the var and rejects an empty result.
+ */
+export function parseAllowedContentServerHosts(raw: string | undefined): Set<string> {
+  const hosts = (raw ?? '')
+    .split(',')
+    .map(normalizeContentServerHost)
+    .filter((h): h is string => h !== undefined)
+  return new Set(hosts)
+}
+
+/**
+ * True when `raw` is an HTTPS URL whose host is exactly on the allowlist. An
+ * exact host match (not a suffix) is intentional — it's the whole point of an
+ * allowlist and the catalyst hosts are a known finite set.
+ */
+export function isAllowedContentServerUrl(raw: string, allowedHosts: Set<string>): boolean {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return false
+  }
+  if (u.protocol !== 'https:') return false
+  const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  return allowedHosts.has(host)
+}
+
+/**
+ * A real entity id is a bare CID (`[a-zA-Z0-9]`). Anything with separators or
+ * `..` is rejected so it can't be interpolated into a filesystem path or an S3
+ * key (path traversal / key injection).
+ */
+export function isValidEntityId(entityId: unknown): entityId is string {
+  return typeof entityId === 'string' && /^[a-zA-Z0-9]+$/.test(entityId)
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -56,6 +56,11 @@ export const metricDeclarations = {
     help: 'Count entities skipped because they are older than the configured max age',
     type: IMetricsComponent.CounterType,
     labelNames: ['entityType']
+  },
+  entity_skipped_invalid_id: {
+    help: 'Count entities skipped because their entityId is not a bare CID (path/key-injection guard)',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['entityType']
   }
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,7 @@
 import { Lifecycle } from '@well-known-components/interfaces'
 import { setupRouter } from './controllers/routes'
 import { AppComponents, GlobalContext, TestComponents } from './types'
+import { isAllowedContentServerUrl, parseAllowedContentServerHosts } from './logic/validation'
 
 // this function wires the business logic (adapters & controllers) with the components (ports)
 export async function main(program: Lifecycle.EntryPointParameters<AppComponents | TestComponents>) {
@@ -19,9 +20,33 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
   components.server.setContext(globalContext)
 
   const contentServerUrls = await components.config.requireString('CONTENT_SERVER_URLS')
+  const servers = contentServerUrls
+    .split(',')
+    .map((url) => url.trim())
+    .filter((url) => url.length > 0)
+
+  // Fail fast on a misconfigured content server: we only ever sync from — and
+  // publish messages pointing at — allowlisted catalyst hosts. This keeps the
+  // downstream asset-bundle-converter's SSRF allowlist (issue #306) and ours in
+  // agreement, and surfaces a typo'd/rogue CONTENT_SERVER_URLS at boot instead
+  // of silently syncing from an unexpected host. The allowlist is sourced
+  // entirely from ALLOWED_CONTENT_SERVER_HOSTS (set per-env in the definitions repo).
+  const allowedContentServerHosts = parseAllowedContentServerHosts(
+    await components.config.requireString('ALLOWED_CONTENT_SERVER_HOSTS')
+  )
+  if (allowedContentServerHosts.size === 0) {
+    throw new Error('ALLOWED_CONTENT_SERVER_HOSTS is set but contains no valid catalyst hosts')
+  }
+  const disallowed = servers.filter((url) => !isAllowedContentServerUrl(url, allowedContentServerHosts))
+  if (disallowed.length > 0) {
+    throw new Error(
+      `CONTENT_SERVER_URLS contains hosts that are not on the catalyst allowlist: ${disallowed.join(', ')}. ` +
+        `Add them to ALLOWED_CONTENT_SERVER_HOSTS or remove them from CONTENT_SERVER_URLS.`
+    )
+  }
 
   // start ports: db, listeners, synchronizations, etc
   await startComponents()
 
-  await components.synchronizer.syncWithServers(new Set(contentServerUrls.split(',')))
+  await components.synchronizer.syncWithServers(new Set(servers))
 }

--- a/test/components.ts
+++ b/test/components.ts
@@ -33,6 +33,10 @@ async function initComponents(): Promise<TestComponents> {
     storage,
     localFetch: await createLocalFetchCompoment(config),
     config: configMock,
-    metrics: metricsMock
+    metrics: metricsMock,
+    // Stub the synchronizer so `main()` doesn't kick off a real catalyst sync
+    // during tests (CONTENT_SERVER_URLS now resolves to a real allowlisted host
+    // to satisfy the startup allowlist guard).
+    synchronizer: { syncWithServers: jest.fn().mockResolvedValue({}) } as any
   }
 }

--- a/test/mocks/components.ts
+++ b/test/mocks/components.ts
@@ -7,7 +7,14 @@ export const configMock: jest.Mocked<IConfigComponent> = {
   getNumber: jest.fn().mockResolvedValue(''),
   getString: jest.fn().mockResolvedValue(''),
   requireNumber: jest.fn().mockResolvedValue('a,b,c'),
-  requireString: jest.fn().mockResolvedValue('a,b,c')
+  // main() validates CONTENT_SERVER_URLS against ALLOWED_CONTENT_SERVER_HOSTS at startup
+  // (the SSRF allowlist guard) and would otherwise throw, so both keys resolve to
+  // matching catalyst values here. Other keys keep the generic placeholder value.
+  requireString: jest.fn().mockImplementation(async (key: string) => {
+    if (key === 'CONTENT_SERVER_URLS') return 'https://peer.decentraland.org/content'
+    if (key === 'ALLOWED_CONTENT_SERVER_HOSTS') return 'peer.decentraland.org'
+    return 'a,b,c'
+  })
 }
 
 export const metricsMock: jest.Mocked<any> = {

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -66,6 +66,20 @@ describe('DeployerComponent', () => {
     jest.clearAllTimers()
   })
 
+  it('should skip and mark as deployed an entity whose entityId is not a bare CID', async () => {
+    const maliciousEntity = { ...mockEntity, entityId: '../../etc/passwd' }
+
+    const deployer = await createDeployerComponent(components)
+    await deployer.scheduleEntityDeployment(maliciousEntity, mockServers)
+
+    expect(metricsMock.increment).toHaveBeenCalledWith('entity_skipped_invalid_id', {
+      entityType: maliciousEntity.entityType
+    })
+    expect(maliciousEntity.markAsDeployed).toHaveBeenCalled()
+    expect(storageMock.exist).not.toHaveBeenCalled()
+    expect(entityDownloaderMock.downloadEntity).not.toHaveBeenCalled()
+  })
+
   it('should call mark as deployed when the entity is already stored', async () => {
     storageMock.exist.mockResolvedValue(true)
 

--- a/test/unit/logic/validation.spec.ts
+++ b/test/unit/logic/validation.spec.ts
@@ -1,0 +1,182 @@
+import {
+  isAllowedContentServerUrl,
+  isValidEntityId,
+  parseAllowedContentServerHosts
+} from '../../../src/logic/validation'
+
+describe('when parsing the ALLOWED_CONTENT_SERVER_HOSTS value', () => {
+  let result: Set<string>
+
+  describe('and the value is undefined', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts(undefined)
+    })
+
+    it('should produce an empty set, since there is no built-in default', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('and the value is an empty string', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('')
+    })
+
+    it('should produce an empty set', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('and the value is a comma-separated list of bare hostnames', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('peer.example.org, peer-2.example.org')
+    })
+
+    it('should trim each entry and return the configured hosts', () => {
+      expect(result).toEqual(new Set(['peer.example.org', 'peer-2.example.org']))
+    })
+  })
+
+  describe('and an entry is a full URL rather than a bare host', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('https://peer.example.org/content')
+    })
+
+    it('should normalize the entry down to its hostname', () => {
+      expect(result).toEqual(new Set(['peer.example.org']))
+    })
+  })
+
+  describe('and the value is uppercased', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('PEER.EXAMPLE.ORG')
+    })
+
+    it('should lowercase the host so matching is case-insensitive', () => {
+      expect(result).toEqual(new Set(['peer.example.org']))
+    })
+  })
+
+  describe('and the value contains only separators and whitespace', () => {
+    beforeEach(() => {
+      result = parseAllowedContentServerHosts('  , ,')
+    })
+
+    it('should produce an empty set', () => {
+      expect(result.size).toBe(0)
+    })
+  })
+})
+
+describe('when validating a content-server URL against the allowlist', () => {
+  let allowedHosts: Set<string>
+  let result: boolean
+
+  beforeEach(() => {
+    allowedHosts = parseAllowedContentServerHosts('peer.decentraland.org')
+  })
+
+  describe('and the URL is an HTTPS host on the allowlist', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('https://peer.decentraland.org/content', allowedHosts)
+    })
+
+    it('should accept it', () => {
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('and the host is not on the allowlist', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('https://evil.example.com/content', allowedHosts)
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and the URL points at the cloud metadata IP', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('https://169.254.169.254/latest/meta-data/', allowedHosts)
+    })
+
+    it('should reject it, since no IP literal is on the allowlist', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and an allowlisted host is requested over plain HTTP', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('http://peer.decentraland.org/content', allowedHosts)
+    })
+
+    it('should reject it, since content servers must be HTTPS', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and the value is not a parseable URL', () => {
+    beforeEach(() => {
+      result = isAllowedContentServerUrl('not a url', allowedHosts)
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+})
+
+describe('when validating an entityId', () => {
+  let result: boolean
+
+  describe('and it is a bare alphanumeric CID', () => {
+    beforeEach(() => {
+      result = isValidEntityId('bafkreiabc123')
+    })
+
+    it('should accept it', () => {
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('and it contains path separators', () => {
+    beforeEach(() => {
+      result = isValidEntityId('../../etc/passwd')
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and it contains a hyphen', () => {
+    beforeEach(() => {
+      result = isValidEntityId('bafy-scene')
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and it is an empty string', () => {
+    beforeEach(() => {
+      result = isValidEntityId('')
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('and it is not a string', () => {
+    beforeEach(() => {
+      result = isValidEntityId(undefined)
+    })
+
+    it('should reject it', () => {
+      expect(result).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
mirrors the asset-bundle-converter ssrf hardening (issue #306) at the producer side.

## what
- **startup allowlist check**: `main()` now rejects boot if `CONTENT_SERVER_URLS` contains a host that is not on the catalyst allowlist. the allowlist comes from the required `ALLOWED_CONTENT_SERVER_HOSTS` env var (comma-separated hosts), set per-env in the `definitions` repo — there is no built-in default list.
- **entityId guard**: the deployer drops any entity whose `entityId` is not a bare cid (`[a-zA-Z0-9]+`) before it is used as a storage key, preventing path/key injection. new `entity_skipped_invalid_id` metric.

## notes
- `src/logic/validation.ts` holds the shared helpers (`parseAllowedContentServerHosts`, `isAllowedCatalystUrl`, `isValidEntityId`).
- all current `CONTENT_SERVER_URLS` hosts are already on the allowlist, so no env behaves differently — but going forward a new content server must also be added to `ALLOWED_CONTENT_SERVER_HOSTS`.

## tests
- new `test/unit/logic/validation.spec.ts`; added a deployer test for the invalid-entityId skip. unit suites green (the `ping-controller` integration test only fails locally due to a macOS port-5000/airplay conflict).

related to decentraland/asset-bundle-converter#306
