### PR TITLE
refactor: adopt @dcl/fetch-component for the catalyst fetcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@aws-sdk/client-sns": "^3.616.0",
     "@dcl/catalyst-storage": "^4.3.0",
+    "@dcl/fetch-component": "^1.0.1",
     "@dcl/schemas": "^15.3.3",
     "@dcl/snapshots-fetcher": "^9.1.0",
     "@well-known-components/env-config-provider": "^1.1.1",

--- a/src/adapters/fetch/index.ts
+++ b/src/adapters/fetch/index.ts
@@ -1,12 +1,17 @@
 import { IFetchComponent } from '@well-known-components/http-server'
-import * as nodeFetch from 'node-fetch'
+import { createFetchComponent as createCoreFetchComponent } from '@dcl/fetch-component'
 
-export async function createFetchComponent() {
-  const fetch: IFetchComponent = {
-    async fetch(url: nodeFetch.RequestInfo, init?: nodeFetch.RequestInit): Promise<nodeFetch.Response> {
-      return nodeFetch.default(url, init)
-    }
-  }
+export async function createFetchComponent(): Promise<IFetchComponent> {
+  // `@dcl/fetch-component` is typed against the native (undici) fetch API, while
+  // `@dcl/snapshots-fetcher` — the only consumer of this component — types its
+  // `fetcher` against `node-fetch`'s `IFetchComponent`. The two Response types
+  // differ structurally, but are compatible at runtime for the calls the
+  // synchronizer actually makes through the fetcher: JSON polling
+  // (`/pointer-changes`, snapshots), which only touches `.ok`/`.status`/`.json()`.
+  // The content-file download path in snapshots-fetcher uses raw `http(s).get`
+  // and does not go through this fetcher at all, so there is no stream-API
+  // mismatch. The type bridge is contained to this single boundary.
+  const fetch = createCoreFetchComponent()
 
-  return fetch
+  return fetch as unknown as IFetchComponent
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,6 +748,13 @@
     destroy "^1.2.0"
     file-type "15"
 
+"@dcl/core-commons@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@dcl/core-commons/-/core-commons-0.10.0.tgz#cbdcc810f55a1a708b9250ab566b951f312841e2"
+  integrity sha512-lcCgnwxkq/MoTbU59wKnspmVaQyEIP8SRRDUCd3Werrwj+nsH6T7xGuVo17cLVEd8D/Hi3NLFtBiq+N7kZAt/A==
+  dependencies:
+    "@well-known-components/interfaces" "^1.5.2"
+
 "@dcl/eslint-config@^1.1.12":
   version "1.1.12"
   resolved "https://registry.npmjs.org/@dcl/eslint-config/-/eslint-config-1.1.12.tgz"
@@ -764,6 +771,13 @@
     eslint-plugin-import "npm:eslint-plugin-i@^2.27.5-3"
     eslint-plugin-prettier "^4.2.1"
     prettier "^2.8.8"
+
+"@dcl/fetch-component@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@dcl/fetch-component/-/fetch-component-1.0.1.tgz#7cfb6d2d2bc6b40c9eca238be212626d511284c4"
+  integrity sha512-OgkOeBtIfxuQ96caFnE+JDORiQEBKajF3DpB7T5ZcoVkbnKGnJ1fmk4eOklzA+Eqt2LOAKsXfKa1RqR9bPwUlg==
+  dependencies:
+    "@dcl/core-commons" "0.10.0"
 
 "@dcl/hashing@^3.0.3":
   version "3.0.4"
@@ -1935,6 +1949,15 @@
   version "1.4.2"
   resolved "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.4.2.tgz"
   integrity sha512-1tkr/OhZ4UmnQiST2svKznEiJ86crV2S+AIhokhowR4MexAKWgYlmZpoP6VIcgDVPf7nu8hOtIPMQaCZ+COC0A==
+  dependencies:
+    "@types/node" "^20.3.1"
+    "@types/node-fetch" "^2.5.12"
+    typed-url-params "^1.0.1"
+
+"@well-known-components/interfaces@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"
+  integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
   dependencies:
     "@types/node" "^20.3.1"
     "@types/node-fetch" "^2.5.12"


### PR DESCRIPTION
## what

adopt the core `@dcl/fetch-component`, replacing the local `node-fetch` wrapper used as `@dcl/snapshots-fetcher`'s `fetcher`.

## how

`@dcl/snapshots-fetcher` is the **only** consumer of this component, and it types its `fetcher` against `node-fetch`'s `IFetchComponent`, while the core component is typed against the native (undici) fetch API. the two `Response` types differ structurally, so the adapter bridges them with a single cast — contained to that one file.

## why this is safe at runtime

I traced exactly how the synchronizer uses the fetcher:

- it uses the fetcher **only** for JSON polling (`/snapshots`, `/pointer-changes`), which touches `.ok` / `.status` / `.json()` — identical on undici and node-fetch
- the only `init` it ever passes is `{ timeout: 15000 }` (in `getSnapshots`). `timeout` is one of the controls the core component supports **natively** (it enforces it via an `AbortController`), so it isn't silently dropped. no node-fetch-specific options (`agent`, `compress`, `size`) are ever passed.
- the content-file **download** path uses raw `http(s).get` and never goes through this fetcher, so there's no web-stream-vs-node-stream mismatch

## behaviour

preserved: GET stays a single attempt (no retries) and the 15s timeout is still honoured. retry/timeout tuning is now a one-line option on the component if we want it later.

## testing

- `yarn build` and `yarn lint:check` pass
- full suite passes (54 tests)
- ⚠️ note: the test suite stubs the synchronizer, so it does **not** exercise the real catalyst sync path. the analysis above is code-level; I'd recommend a quick smoke test against a real catalyst (`/pointer-changes`) in a staging/dev run before merging, since this sits on the deployment-critical sync path.

## note

independent of #527 (SNS) and #528 (http-server + metrics). all three touch `package.json` / `yarn.lock`, so whichever merges later will need a trivial rebase.
