### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
 ARG RUN
 
-FROM node:lts as builderenv
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as builderenv
 
 WORKDIR /app
 
-# some packages require a build step
-RUN apt-get update
-RUN apt-get -y -qq install python3-setuptools python3-dev build-essential
-
-# We use Tini to handle signals and PID1 (https://github.com/krallin/tini, read why here https://github.com/krallin/tini/issues/8)
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+# some packages require a build step (node-gyp toolchain)
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 # install dependencies
 COPY package.json /app/package.json
@@ -28,18 +22,20 @@ RUN yarn install --frozen-lockfile --production
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:lts
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production
 
+# We use Tini to handle signals and PID1 (https://github.com/krallin/tini, read why here https://github.com/krallin/tini/issues/8)
+RUN apk add --no-cache tini
+
 WORKDIR /app
 COPY --from=builderenv /app /app
-COPY --from=builderenv /tini /tini
 # Please _DO NOT_ use a custom ENTRYPOINT because it may prevent signals
 # (i.e. SIGTERM) to reach the service
 # Read more here: https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/
 #            and: https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 # Run the program under Tini
 CMD [ "/usr/local/bin/node", "--trace-warnings", "--abort-on-uncaught-exception", "--unhandled-rejections=strict", "dist/index.js" ]


### PR DESCRIPTION
Switches the base image to `node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995` (was `node:lts`) and pins it to an immutable sha256 digest for reproducible builds.

This service has **no glibc-only dependencies** — `@well-known-components/http-server` is Express-based and the only native addon is `fsevents` (macOS-only) — so it runs cleanly on alpine/musl. The Dockerfile was adapted for alpine: builder `apt-get` → `apk add python3 py3-setuptools make g++`, and **tini** is now installed via `apk` (the downloaded `tini` release binary is glibc-linked and won't run on musl) with the `/sbin/tini` entrypoint.