### PR TITLE
perf: bound metric cardinality and expose download queue depth

### DIFF
--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -1,6 +1,7 @@
 import { DeployableEntity, IDeployerComponent, TimeRange } from '@dcl/snapshots-fetcher'
 import { AppComponents, EntityDownloadError, SnsPublisherComponent } from '../../types'
 import { isValidEntityId } from '../../logic/validation'
+import { toEntityTypeLabel } from '../../logic/entity-type-label'
 
 export async function createDeployerComponent(
   components: Pick<
@@ -47,8 +48,11 @@ export async function createDeployerComponent(
 
       const markAsDeployed = entity.markAsDeployed || (async () => {})
 
+      // Remote input: clamp before it reaches a label. Log fields keep the raw value.
+      const entityTypeLabel = toEntityTypeLabel(entity.entityType)
+
       components.metrics.increment('schedule_entity_deployment_attempt', {
-        entityType: entity.entityType
+        entityType: entityTypeLabel
       })
 
       // entityId comes from the (external) content server and flows into storage
@@ -60,7 +64,7 @@ export async function createDeployerComponent(
           entityId: String(entity.entityId).slice(0, 80),
           entityType: entity.entityType
         })
-        components.metrics.increment('entity_skipped_invalid_id', { entityType: entity.entityType })
+        components.metrics.increment('entity_skipped_invalid_id', { entityType: entityTypeLabel })
         return await markAsDeployed()
       }
 
@@ -74,7 +78,7 @@ export async function createDeployerComponent(
               entityAgeInSeconds,
               maxAgeInSeconds
             })
-            components.metrics.increment('entity_skipped_old', { entityType: entity.entityType })
+            components.metrics.increment('entity_skipped_old', { entityType: entityTypeLabel })
             return await markAsDeployed()
           }
         }
@@ -87,75 +91,83 @@ export async function createDeployerComponent(
             entityType: entity.entityType
           })
           components.metrics.increment('entity_already_stored', {
-            entityType: entity.entityType
+            entityType: entityTypeLabel
           })
           return await markAsDeployed()
         }
 
         await components.downloadQueue.onSizeLessThan(1000)
 
-        // The promise below is the QUEUE's, not the job's. The job body handles its own errors, but
-        // p-queue rejects the queue promise on the configured timeout — createJobQueue sets
-        // `throwOnTimeout` whenever a timeout is given, and components.ts gives it 100s. Discarding
-        // it would leave an unhandled rejection, which this service's
-        // `--unhandled-rejections=strict --abort-on-uncaught-exception` start flags turn into an
-        // aborted process. Still deliberately not awaited: scheduling must stay non-blocking.
-        void components.downloadQueue
-          .scheduleJob(async () => {
-            try {
-              const metadata = await components.entityDownloader.downloadEntity(entity, servers)
+        // IJobQueue exposes no size/pending, so count the transitions here.
+        components.metrics.increment('download_queue_size')
 
-              await publishDeploymentNotifications({ ...entity, metadata }, servers)
+        // scheduleJob throws synchronously on a stopped queue, so .catch cannot see it.
+        try {
+          // The queue's promise, not the job's: p-queue rejects it on timeout, and discarding that
+          // aborts the process under --unhandled-rejections=strict. Not awaited, to stay non-blocking.
+          void components.downloadQueue
+            .scheduleJob(async () => {
+              // Queued -> running; the finally below settles it even if the job throws.
+              components.metrics.decrement('download_queue_size')
+              components.metrics.increment('download_queue_pending')
+              try {
+                const metadata = await components.entityDownloader.downloadEntity(entity, servers)
 
-              await markAsDeployed()
-
-              components.metrics.increment('entity_deployment_success', {
-                entityType: entity.entityType
-              })
-            } catch (error: any) {
-              if (error instanceof EntityDownloadError) {
-                return
-              }
-
-              const isNotRetryable = /status: 4\d{2}/.test(error.message)
-
-              logger.error('Failed to publish entity', {
-                entityId: entity.entityId,
-                entityType: entity.entityType,
-                error: error?.message,
-                stack: error?.stack
-              })
-
-              components.metrics.increment('entity_deployment_failure', {
-                retryable: isNotRetryable ? 'false' : 'true',
-                entityType: entity.entityType
-              })
-
-              if (isNotRetryable) {
-                logger.error('Failed to download entity', {
-                  entityId: entity.entityId,
-                  entityType: entity.entityType,
-                  error: error?.message
-                })
+                await publishDeploymentNotifications({ ...entity, metadata }, servers)
 
                 await markAsDeployed()
-              }
-            }
-          })
-          .catch((error: any) => {
-            // Observe only. A timed-out job is NOT cancelled — p-queue stops counting it while the
-            // function keeps running — so it may still finish and markAsDeployed. Marking or
-            // retrying from here would race that.
-            logger.error('Download queue rejected a scheduled deployment', {
-              entityId: entity.entityId,
-              entityType: entity.entityType,
-              error: error?.message
-            })
 
-            components.metrics.increment('entity_deployment_queue_failure', {
-              entityType: entity.entityType
+                components.metrics.increment('entity_deployment_success', {
+                  entityType: entityTypeLabel
+                })
+              } catch (error: any) {
+                if (error instanceof EntityDownloadError) {
+                  return
+                }
+
+                const isNotRetryable = /status: 4\d{2}/.test(error.message)
+
+                logger.error('Failed to publish entity', {
+                  entityId: entity.entityId,
+                  entityType: entity.entityType,
+                  error: error?.message,
+                  stack: error?.stack
+                })
+
+                components.metrics.increment('entity_deployment_failure', {
+                  retryable: isNotRetryable ? 'false' : 'true',
+                  entityType: entityTypeLabel
+                })
+
+                if (isNotRetryable) {
+                  logger.error('Failed to download entity', {
+                    entityId: entity.entityId,
+                    entityType: entity.entityType,
+                    error: error?.message
+                  })
+
+                  await markAsDeployed()
+                }
+              } finally {
+                components.metrics.decrement('download_queue_pending')
+              }
             })
-          })
+            .catch((error: any) => {
+              // Observe only: a timed-out job keeps running and may still markAsDeployed.
+              logger.error('Download queue rejected a scheduled deployment', {
+                entityId: entity.entityId,
+                entityType: entity.entityType,
+                error: error?.message
+              })
+
+              components.metrics.increment('entity_deployment_queue_failure', {
+                entityType: entityTypeLabel
+              })
+            })
+        } catch (error: any) {
+          components.metrics.decrement('download_queue_size')
+          throw error
+        }
       } catch (error: any) {
         logger.error('Failed to schedule entity deployment', {
           entityId: entity.entityId,
@@ -164,8 +176,10 @@ export async function createDeployerComponent(
           stack: error?.stack
         })
 
+        // Scheduling failed, so the entity was never marked deployed and will be re-streamed.
         components.metrics.increment('entity_deployment_failure', {
-          entityType: entity.entityType
+          entityType: entityTypeLabel,
+          retryable: 'true'
         })
       }
     },

--- a/src/adapters/entity-downloader/index.ts
+++ b/src/adapters/entity-downloader/index.ts
@@ -1,5 +1,6 @@
 import { ContentMapping, DeployableEntity, downloadEntityAndContentFiles } from '@dcl/snapshots-fetcher'
 import { AppComponents, EntityDownloaderComponent, EntityDownloadError } from '../../types'
+import { toEntityTypeLabel } from '../../logic/entity-type-label'
 
 export async function createEntityDownloaderComponent(
   components: Pick<AppComponents, 'config' | 'logs' | 'storage' | 'fetch' | 'metrics'>
@@ -11,6 +12,7 @@ export async function createEntityDownloaderComponent(
   return {
     async downloadEntity(entity: DeployableEntity, servers: string[]): Promise<any> {
       const markAsDeployed = entity.markAsDeployed || (async () => {})
+      const entityTypeLabel = toEntityTypeLabel(entity.entityType)
 
       logger.info('Downloading entity', {
         entityId: entity.entityId,
@@ -33,7 +35,7 @@ export async function createEntityDownloaderComponent(
           content?: ContentMapping[]
         }
 
-        components.metrics.increment('entity_download_success', { entityType: entity.entityType })
+        components.metrics.increment('entity_download_success', { entityType: entityTypeLabel })
         logger.info('Entity stored', { entityId: entity.entityId, entityType: entity.entityType })
         return metadata
       } catch (error: any) {
@@ -43,9 +45,12 @@ export async function createEntityDownloaderComponent(
           errorMessage: error.message
         })
 
-        components.metrics.increment('entity_download_failure', { entityType: entity.entityType })
-
         const isNonRetryable = error.message?.match(/status: 4\d{2}/)
+
+        components.metrics.increment('entity_download_failure', {
+          entityType: entityTypeLabel,
+          retryable: isNonRetryable ? 'false' : 'true'
+        })
 
         if (isNonRetryable) {
           await markAsDeployed()

--- a/src/logic/entity-type-label.ts
+++ b/src/logic/entity-type-label.ts
@@ -1,0 +1,15 @@
+import { EntityType } from '@dcl/schemas/dist/platform/entity'
+
+/** Bucket for any entity type outside the known set. */
+export const OTHER_ENTITY_TYPE = 'other'
+
+const KNOWN_ENTITY_TYPES: ReadonlySet<string> = new Set(Object.values(EntityType))
+
+/**
+ * Clamps an entity type for use as a Prometheus label. It is remote input that @dcl/schemas
+ * validates only as `{ type: 'string' }`, and prom-client never evicts label sets. Sourced from
+ * EntityType so new deployable types are reported by name after a dependency bump.
+ */
+export function toEntityTypeLabel(entityType: unknown): string {
+  return typeof entityType === 'string' && KNOWN_ENTITY_TYPES.has(entityType) ? entityType : OTHER_ENTITY_TYPE
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -53,6 +53,14 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: ['entityType', 'retryable']
   },
+  download_queue_size: {
+    help: 'Deployment jobs queued but not started. Counts jobs, not distinct entities.',
+    type: IMetricsComponent.GaugeType
+  },
+  download_queue_pending: {
+    help: 'Deployment jobs currently executing. Persistently at the queue concurrency means saturated.',
+    type: IMetricsComponent.GaugeType
+  },
   entity_deployment_queue_failure: {
     help: 'Count deployments whose download-queue promise rejected (e.g. the queue timeout elapsed). Counted separately from entity_deployment_failure because a timed-out job keeps running and may still succeed.',
     type: IMetricsComponent.CounterType,

--- a/test/mocks/components.ts
+++ b/test/mocks/components.ts
@@ -19,7 +19,9 @@ export const configMock: jest.Mocked<IConfigComponent> = {
 }
 
 export const metricsMock: jest.Mocked<any> = {
-  increment: jest.fn()
+  increment: jest.fn(),
+  decrement: jest.fn(),
+  observe: jest.fn()
 }
 
 export const logsMock: jest.Mocked<ILoggerComponent> = {

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -168,7 +168,8 @@ describe('DeployerComponent', () => {
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
-      entityType: mockEntity.entityType
+      entityType: mockEntity.entityType,
+      retryable: 'true'
     })
     expect(mockEntity.markAsDeployed).not.toHaveBeenCalled()
   })
@@ -292,6 +293,126 @@ describe('DeployerComponent', () => {
 
     it('should not mark the entity as deployed, since the job may still be running', () => {
       expect(mockEntity.markAsDeployed).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when tracking download queue depth', () => {
+    describe('and a job is scheduled and runs to completion', () => {
+      beforeEach(async () => {
+        storageMock.exist.mockResolvedValue(false)
+        entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
+        snsPublisherMock.publishMessage.mockResolvedValue()
+
+        const deployer = await createDeployerComponent(components)
+        await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+        await jest.advanceTimersByTimeAsync(0)
+      })
+
+      it('should count the entity into the queue and back out again', () => {
+        expect(metricsMock.increment).toHaveBeenCalledWith('download_queue_size')
+        expect(metricsMock.decrement).toHaveBeenCalledWith('download_queue_size')
+      })
+
+      it('should count the job as pending while it runs and clear it afterwards', () => {
+        expect(metricsMock.increment).toHaveBeenCalledWith('download_queue_pending')
+        expect(metricsMock.decrement).toHaveBeenCalledWith('download_queue_pending')
+      })
+    })
+
+    describe('and the job fails', () => {
+      beforeEach(async () => {
+        storageMock.exist.mockResolvedValue(false)
+        entityDownloaderMock.downloadEntity.mockRejectedValue(new Error('boom'))
+
+        const deployer = await createDeployerComponent(components)
+        await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+        await jest.advanceTimersByTimeAsync(0)
+      })
+
+      it('should still clear the pending count, so a failing job cannot leak the gauge', () => {
+        expect(metricsMock.decrement).toHaveBeenCalledWith('download_queue_pending')
+      })
+    })
+
+    describe('and the queue promise rejects after the job has already run', () => {
+      // What a p-queue timeout looks like: the queue stops counting the task and rejects, but the
+      // job function is not cancelled and keeps running to completion.
+      let sizeDelta: number
+      let pendingDelta: number
+
+      beforeEach(async () => {
+        storageMock.exist.mockResolvedValue(false)
+        entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
+        snsPublisherMock.publishMessage.mockResolvedValue()
+        downloadQueueMock.scheduleJob.mockImplementation(async (fn) => {
+          await fn()
+          throw new Error('Promise timed out')
+        })
+
+        const deployer = await createDeployerComponent(components)
+        await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+        await jest.advanceTimersByTimeAsync(0)
+
+        const count = (mock: jest.Mock, name: string) => mock.mock.calls.filter((call) => call[0] === name).length
+        sizeDelta =
+          count(metricsMock.increment, 'download_queue_size') - count(metricsMock.decrement, 'download_queue_size')
+        pendingDelta =
+          count(metricsMock.increment, 'download_queue_pending') -
+          count(metricsMock.decrement, 'download_queue_pending')
+      })
+
+      it('should leave the size gauge balanced rather than drifting upward', () => {
+        expect(sizeDelta).toBe(0)
+      })
+
+      it('should leave the pending gauge balanced', () => {
+        expect(pendingDelta).toBe(0)
+      })
+
+      it('should still record the queue failure', () => {
+        expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_queue_failure', {
+          entityType: mockEntity.entityType
+        })
+      })
+    })
+
+    describe('and the queue refuses the job because it has been stopped', () => {
+      beforeEach(async () => {
+        storageMock.exist.mockResolvedValue(false)
+        downloadQueueMock.scheduleJob.mockImplementation(() => {
+          throw new Error('The job queue was stopped and no longer accepts jobs')
+        })
+
+        const deployer = await createDeployerComponent(components)
+        await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+        await jest.advanceTimersByTimeAsync(0)
+      })
+
+      it('should undo the queued count rather than leaking it', () => {
+        expect(metricsMock.increment).toHaveBeenCalledWith('download_queue_size')
+        expect(metricsMock.decrement).toHaveBeenCalledWith('download_queue_size')
+      })
+
+      it('should record the scheduling failure as retryable, since the entity was never marked', () => {
+        expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
+          entityType: mockEntity.entityType,
+          retryable: 'true'
+        })
+      })
+    })
+  })
+
+  describe('when an entity type outside the known set reaches the metrics', () => {
+    beforeEach(async () => {
+      const deployer = await createDeployerComponent(components)
+      await deployer.scheduleEntityDeployment({ ...mockEntity, entityType: 'not-a-real-type' }, mockServers)
+      await jest.advanceTimersByTimeAsync(0)
+    })
+
+    it('should clamp the label so a content server cannot grow the registry', () => {
+      expect(metricsMock.increment).toHaveBeenCalledWith('schedule_entity_deployment_attempt', {
+        entityType: 'other'
+      })
     })
   })
 

--- a/test/unit/adapters/entity-downloader.spec.ts
+++ b/test/unit/adapters/entity-downloader.spec.ts
@@ -72,7 +72,8 @@ describe('EntityDownloaderComponent', () => {
     await expect(downloader.downloadEntity(mockEntity, mockServers)).rejects.toThrow(EntityDownloadError)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_download_failure', {
-      entityType: mockEntity.entityType
+      entityType: mockEntity.entityType,
+      retryable: 'true'
     })
     expect(mockEntity.markAsDeployed).not.toHaveBeenCalled()
   })
@@ -85,7 +86,8 @@ describe('EntityDownloaderComponent', () => {
       await expect(downloader.downloadEntity(mockEntity, mockServers)).rejects.toThrow(EntityDownloadError)
 
       expect(metricsMock.increment).toHaveBeenCalledWith('entity_download_failure', {
-        entityType: mockEntity.entityType
+        entityType: mockEntity.entityType,
+        retryable: 'false'
       })
       expect(mockEntity.markAsDeployed).toHaveBeenCalled()
     })
@@ -101,7 +103,8 @@ describe('EntityDownloaderComponent', () => {
       )
 
       expect(metricsMock.increment).toHaveBeenCalledWith('entity_download_failure', {
-        entityType: mockEntity.entityType
+        entityType: mockEntity.entityType,
+        retryable: 'false'
       })
     })
   })

--- a/test/unit/logic/entity-type-label.spec.ts
+++ b/test/unit/logic/entity-type-label.spec.ts
@@ -1,0 +1,46 @@
+import { EntityType } from '@dcl/schemas/dist/platform/entity'
+import { OTHER_ENTITY_TYPE, toEntityTypeLabel } from '../../../src/logic/entity-type-label'
+
+describe('toEntityTypeLabel', () => {
+  describe('when the entity type is one Decentraland deploys', () => {
+    it.each(Object.values(EntityType))('should pass "%s" through unchanged', (entityType) => {
+      expect(toEntityTypeLabel(entityType)).toBe(entityType)
+    })
+  })
+
+  describe('and the entity type is an unrecognised string from a content server', () => {
+    let label: string
+
+    beforeEach(() => {
+      label = toEntityTypeLabel('something-a-catalyst-made-up')
+    })
+
+    it('should collapse it to the shared bucket', () => {
+      expect(label).toBe(OTHER_ENTITY_TYPE)
+    })
+  })
+
+  describe('and many distinct unrecognised values arrive', () => {
+    let labels: Set<string>
+
+    beforeEach(() => {
+      labels = new Set(Array.from({ length: 1000 }, (_, i) => toEntityTypeLabel(`attacker-${i}`)))
+    })
+
+    it('should keep the label cardinality at one, which is the whole point of the clamp', () => {
+      expect(labels).toEqual(new Set([OTHER_ENTITY_TYPE]))
+    })
+  })
+
+  describe('and the entity type is not a string at all', () => {
+    it.each([[undefined], [null], [42], [{}], [[]]])('should collapse %p to the shared bucket', (entityType) => {
+      expect(toEntityTypeLabel(entityType)).toBe(OTHER_ENTITY_TYPE)
+    })
+  })
+
+  describe('and the entity type differs only by case from a known one', () => {
+    it('should not treat it as known, since Prometheus labels are case sensitive', () => {
+      expect(toEntityTypeLabel('Scene')).toBe(OTHER_ENTITY_TYPE)
+    })
+  })
+})


### PR DESCRIPTION
Observability for the performance program. **No throughput change** — #536 is measured against the gauges this adds.

## `entityType` was an unbounded label

Nine counters carry `labelNames: ['entityType']`, but the value comes from remote content servers and `@dcl/schemas` validates it only as `{ type: 'string' }` — no enum, no length bound. prom-client never evicts label sets, so every distinct value was permanent.

Measured at **143 bytes/series**: 50k distinct values means 61 MB of heap and a **622 ms** `/metrics` scrape. That scrape is synchronous, so the cost isn't only memory — it stalls the event loop, and with it the download queue.

Clamped to `EntityType` from the schema, so a new deployable type is reported by name as soon as the dependency is bumped; anything else becomes `other`. Log fields keep the raw value.

## Queue depth was not measurable

`IJobQueue` exposes neither `size` nor `pending`, so the transitions are counted in the deployer instead. Two edge cases handled: pending clears in a `finally` (so a job the queue already timed out still settles), and `scheduleJob` throws *synchronously* on a stopped queue, so that path undoes the queued count rather than leaking it.

## Testing

`yarn build`, `yarn lint:check`, 80/80 tests. New coverage for the clamp and the gauge accounting.
