### PR TITLE
perf: split the deployer and synchronizer queues and widen concurrency

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -29,3 +29,13 @@ ALLOWED_CONTENT_SERVER_HOSTS=peer.decentraland.org,peer-ec1.decentraland.org,pee
 # (no download, no SNS publish). Useful during catalyst reprocessing to drain the backlog without
 # propagating old events downstream. Disabled when unset, 0, or non-numeric.
 ENTITY_MAX_AGE_IN_SECONDS=
+
+# --- Throughput tuning -------------------------------------------------------
+# All optional. Unset takes the default; a non-integer or < 1 fails at boot.
+# In-flight ceiling is DOWNLOAD_QUEUE_CONCURRENCY x CONTENT_FILES_CONCURRENCY.
+DOWNLOAD_QUEUE_CONCURRENCY=
+DOWNLOAD_QUEUE_TIMEOUT_MS=
+DOWNLOAD_QUEUE_MAX_PENDING=
+SYNCHRONIZER_QUEUE_CONCURRENCY=
+SYNCHRONIZER_QUEUE_TIMEOUT_MS=
+CONTENT_FILES_CONCURRENCY=

--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -2,6 +2,7 @@ import { DeployableEntity, IDeployerComponent, TimeRange } from '@dcl/snapshots-
 import { AppComponents, EntityDownloadError, SnsPublisherComponent } from '../../types'
 import { isValidEntityId } from '../../logic/validation'
 import { toEntityTypeLabel } from '../../logic/entity-type-label'
+import { getPositiveInt } from '../../logic/tuning'
 
 export async function createDeployerComponent(
   components: Pick<
@@ -20,6 +21,9 @@ export async function createDeployerComponent(
   const logger = components.logs.getLogger('Deployer')
 
   const maxAgeInSeconds = parseInt((await components.config.getString('ENTITY_MAX_AGE_IN_SECONDS')) ?? '', 10)
+
+  // Blocks the stream, not just the queue: scheduleEntityDeployment is awaited per entity.
+  const maxPendingDeployments = await getPositiveInt(components.config, 'DOWNLOAD_QUEUE_MAX_PENDING', 1000)
 
   if (maxAgeInSeconds > 0) {
     logger.info('Entity age filter enabled', { maxAgeInSeconds })
@@ -96,7 +100,7 @@ export async function createDeployerComponent(
           return await markAsDeployed()
         }
 
-        await components.downloadQueue.onSizeLessThan(1000)
+        await components.downloadQueue.onSizeLessThan(maxPendingDeployments)
 
         // IJobQueue exposes no size/pending, so count the transitions here.
         components.metrics.increment('download_queue_size')

--- a/src/adapters/entity-downloader/index.ts
+++ b/src/adapters/entity-downloader/index.ts
@@ -1,6 +1,7 @@
 import { ContentMapping, DeployableEntity, downloadEntityAndContentFiles } from '@dcl/snapshots-fetcher'
 import { AppComponents, EntityDownloaderComponent, EntityDownloadError } from '../../types'
 import { toEntityTypeLabel } from '../../logic/entity-type-label'
+import { getPositiveInt } from '../../logic/tuning'
 
 export async function createEntityDownloaderComponent(
   components: Pick<AppComponents, 'config' | 'logs' | 'storage' | 'fetch' | 'metrics'>
@@ -8,6 +9,10 @@ export async function createEntityDownloaderComponent(
   const logger = components.logs.getLogger('EntityDownloader')
   const maxRetries: number = (await components.config.getNumber('MAX_RETRIES')) || 10
   const waitTimeBetweenRetries: number = (await components.config.getNumber('WAIT_TIME_BETWEEN_RETRIES')) || 1000
+
+  // Per entity, and there is no global bound, so the in-flight ceiling is
+  // DOWNLOAD_QUEUE_CONCURRENCY x this. Lowered from the library default of 10.
+  const contentFilesConcurrency = await getPositiveInt(components.config, 'CONTENT_FILES_CONCURRENCY', 4)
 
   return {
     async downloadEntity(entity: DeployableEntity, servers: string[]): Promise<any> {
@@ -28,7 +33,8 @@ export async function createEntityDownloaderComponent(
           new Map(),
           'content',
           maxRetries,
-          waitTimeBetweenRetries
+          waitTimeBetweenRetries,
+          contentFilesConcurrency
         )) as {
           type: string
           metadata?: any

--- a/src/components.ts
+++ b/src/components.ts
@@ -8,6 +8,7 @@ import { createLogComponent } from '@well-known-components/logger'
 import { createFetchComponent } from '@dcl/fetch-component'
 import { createMetricsComponent } from '@dcl/metrics'
 import { AppComponents, GlobalContext } from './types'
+import { getPositiveInt } from './logic/tuning'
 import { metricDeclarations } from './metrics'
 import {
   createJobQueue,
@@ -50,10 +51,19 @@ export async function initComponents(): Promise<AppComponents> {
 
   const storage = createResilientContentStorage({ logs }, rawStorage)
 
+  // Separate queues so `deployer.onIdle()` — awaited at every poll of every server — drains only
+  // the deployer's work, and /snapshots fetches never queue behind an entity backlog.
   const downloadQueue = createJobQueue({
     autoStart: true,
-    concurrency: 5,
-    timeout: 100000
+    concurrency: await getPositiveInt(config, 'DOWNLOAD_QUEUE_CONCURRENCY', 15),
+    timeout: await getPositiveInt(config, 'DOWNLOAD_QUEUE_TIMEOUT_MS', 100000)
+  })
+
+  // Sized for snapshotDeployments (default 10) plus the per-server /snapshots fetches.
+  const synchronizerQueue = createJobQueue({
+    autoStart: true,
+    concurrency: await getPositiveInt(config, 'SYNCHRONIZER_QUEUE_CONCURRENCY', 10),
+    timeout: await getPositiveInt(config, 'SYNCHRONIZER_QUEUE_TIMEOUT_MS', 100000)
   })
 
   const snsPublisher = await createSnsDeploymentPublisherComponent({ config, logs, metrics })
@@ -102,7 +112,7 @@ export async function initComponents(): Promise<AppComponents> {
   const synchronizer = await createSynchronizer(
     {
       logs,
-      downloadQueue,
+      downloadQueue: synchronizerQueue,
       fetcher: fetch,
       metrics,
       deployer,
@@ -146,6 +156,7 @@ export async function initComponents(): Promise<AppComponents> {
     storage,
     fs,
     downloadQueue,
+    synchronizerQueue,
     synchronizer,
     deployer,
     snsPublisher,

--- a/src/logic/tuning.ts
+++ b/src/logic/tuning.ts
@@ -1,0 +1,22 @@
+import { IConfigComponent } from '@well-known-components/interfaces'
+
+/**
+ * Reads a positive-integer tuning knob. Throws on an invalid value rather than falling back, since
+ * a knob that silently resolves to 0 or NaN would stall the pipeline or remove a bound. Only an
+ * unset value takes the default.
+ */
+export async function getPositiveInt(config: IConfigComponent, key: string, defaultValue: number): Promise<number> {
+  const raw = await config.getString(key)
+
+  if (raw === undefined || raw === null || raw.trim() === '') {
+    return defaultValue
+  }
+
+  const parsed = Number(raw)
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${key} must be an integer >= 1, got "${raw}"`)
+  }
+
+  return parsed
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,10 @@ export type BaseComponents = {
   logs: ILoggerComponent
   server: IHttpServerComponent<GlobalContext>
   fetch: IFetchComponent
+  /** Entity downloads; what `deployer.onIdle()` drains. */
   downloadQueue: IJobQueue
+  /** The synchronizer's control plane, kept off the entity queue. */
+  synchronizerQueue: IJobQueue
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
   fs: IFileSystemComponent
   storage: IContentStorageComponent

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -28,13 +28,20 @@ describe('DeployerComponent', () => {
     >
   >
 
+  // The deployer reads several string knobs. Scope the value under test to its own key so it does
+  // not also land on DOWNLOAD_QUEUE_MAX_PENDING, which rejects non-positive-integer values.
+  const setEntityMaxAge = (value: string) =>
+    configMock.getString.mockImplementation(async (key: string) =>
+      key === 'ENTITY_MAX_AGE_IN_SECONDS' ? value : undefined
+    )
+
   let mockEntity: DeployableEntity
   let mockServers: string[]
 
   beforeEach(() => {
     downloadQueueMock.onSizeLessThan.mockResolvedValue()
     downloadQueueMock.scheduleJob.mockImplementation(async (fn) => await fn())
-    configMock.getString.mockResolvedValue('')
+    setEntityMaxAge('')
 
     components = {
       config: configMock,
@@ -177,7 +184,7 @@ describe('DeployerComponent', () => {
   describe('entity age filter', () => {
     it('should skip and mark as deployed entities older than the configured max age', async () => {
       const maxAgeInSeconds = 3600
-      configMock.getString.mockResolvedValue(String(maxAgeInSeconds))
+      setEntityMaxAge(String(maxAgeInSeconds))
       const oldTimestamp = Date.now() - (maxAgeInSeconds + 1) * 1000
       const oldEntity = { ...mockEntity, entityTimestamp: oldTimestamp }
 
@@ -195,7 +202,7 @@ describe('DeployerComponent', () => {
 
     it('should process recent entities normally when the age filter is enabled', async () => {
       const maxAgeInSeconds = 3600
-      configMock.getString.mockResolvedValue(String(maxAgeInSeconds))
+      setEntityMaxAge(String(maxAgeInSeconds))
       storageMock.exist.mockResolvedValue(false)
       entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
       snsPublisherMock.publishMessage.mockResolvedValue()
@@ -212,7 +219,7 @@ describe('DeployerComponent', () => {
 
     it('should not skip an entity aged exactly at the threshold', async () => {
       const maxAgeInSeconds = 3600
-      configMock.getString.mockResolvedValue(String(maxAgeInSeconds))
+      setEntityMaxAge(String(maxAgeInSeconds))
       storageMock.exist.mockResolvedValue(false)
       entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
       snsPublisherMock.publishMessage.mockResolvedValue()
@@ -231,7 +238,7 @@ describe('DeployerComponent', () => {
     it.each(['', '0', 'abc', '-3600'])(
       'should process all entities when config is "%s" (filter disabled)',
       async (configValue) => {
-        configMock.getString.mockResolvedValue(configValue)
+        setEntityMaxAge(configValue)
         storageMock.exist.mockResolvedValue(false)
         entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
         snsPublisherMock.publishMessage.mockResolvedValue()

--- a/test/unit/adapters/entity-downloader.spec.ts
+++ b/test/unit/adapters/entity-downloader.spec.ts
@@ -57,7 +57,8 @@ describe('EntityDownloaderComponent', () => {
       new Map(),
       'content',
       10,
-      1000
+      1000,
+      4
     )
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_download_success', {
       entityType: mockEntity.entityType

--- a/test/unit/logic/tuning.spec.ts
+++ b/test/unit/logic/tuning.spec.ts
@@ -1,0 +1,55 @@
+import { IConfigComponent } from '@well-known-components/interfaces'
+import { getPositiveInt } from '../../../src/logic/tuning'
+
+describe('getPositiveInt', () => {
+  let config: jest.Mocked<IConfigComponent>
+
+  beforeEach(() => {
+    config = {
+      getString: jest.fn(),
+      getNumber: jest.fn(),
+      requireString: jest.fn(),
+      requireNumber: jest.fn()
+    }
+  })
+
+  describe('when the variable is not set', () => {
+    it.each([[undefined], [null], [''], ['   ']])('should fall back to the default for %p', async (raw) => {
+      config.getString.mockResolvedValue(raw as any)
+
+      await expect(getPositiveInt(config, 'SOME_KNOB', 15)).resolves.toBe(15)
+    })
+  })
+
+  describe('when the variable holds a positive integer', () => {
+    let value: number
+
+    beforeEach(async () => {
+      config.getString.mockResolvedValue('40')
+      value = await getPositiveInt(config, 'SOME_KNOB', 15)
+    })
+
+    it('should use the configured value rather than the default', () => {
+      expect(value).toBe(40)
+    })
+  })
+
+  describe('when the variable holds a value that would silently break a bound', () => {
+    it.each([['0'], ['-1'], ['1.5'], ['abc'], ['1e3x'], ['Infinity']])(
+      'should throw for %p rather than fall back',
+      async (raw) => {
+        config.getString.mockResolvedValue(raw)
+
+        await expect(getPositiveInt(config, 'SOME_KNOB', 15)).rejects.toThrow('SOME_KNOB must be an integer >= 1')
+      }
+    )
+  })
+
+  describe('when the variable has surrounding whitespace', () => {
+    it('should still parse it, since env files commonly carry trailing spaces', async () => {
+      config.getString.mockResolvedValue(' 25 ')
+
+      await expect(getPositiveInt(config, 'SOME_KNOB', 15)).resolves.toBe(25)
+    })
+  })
+})


### PR DESCRIPTION
> **Stacked on #535** — base is `perf/observability`, not `main`. PR 2 of the staged performance program. The gauges #535 adds are how this PR is measured, and both touch the deployer, so stacking avoids a conflict. Merge #535 first and the base retargets automatically.

## Result

Two identical 40-second runs against `peer.decentraland.zone`, same protocol as the baseline:

| | scheduled | stored | store rate |
|---|---|---|---|
| concurrency 5 (old) | 1,319 | 333 | **7.9/s** |
| concurrency 15 (new) | 2,112 | 1,175 | **27.6/s** |

**~3.5×.** Zero download failures, zero queue rejections, zero non-SNS errors at either level.

The scheduling histogram shows the starvation lifting directly — at concurrency 5 the rate collapses to 4–12/s after the first second; at 15 it sustains 16–96/s:

```
conc  5:  t+0s:1009  t+2s:5   t+4s:5   t+5s:60  t+6s:4   t+7s:12
conc 15:  t+0s:1160  t+1s:96  t+2s:80  t+3s:32  t+4s:28  t+5s:16
```

## One queue was doing three jobs

`createJobQueue` was a single instance shared by the deployer and `createSynchronizer`, which coupled three unrelated things:

1. **`deployer.onIdle()` is a global barrier.** snapshots-fetcher awaits it at the end of *every poll of every server* (`synchronizer.js:498`, the `onPollEnd` callback). On a shared queue, server A's poll could not close until entities scheduled by servers B–F — *and the synchronizer's own `/snapshots` fetches* — had all drained. Six independent streams serialized behind the slowest download.
2. **Control-plane head-of-line blocking.** `/snapshots` fetches (`client.js:62`) sat behind a backlog of up to 1,000 entities. p-queue applies `timeout` only once a job *starts*, so they stalled silently rather than timing out.
3. **Entity throughput was capped by a concurrency sized for the control plane.**

Split, `onIdle()` means "this deployer's work drained" — the contract snapshots-fetcher actually needs — and each side is sized for its own job. This is also why the barrier only became expensive recently: #534 changed `onIdle()` from a no-op to a real drain (a necessary correctness fix — the no-op silently skipped deployments), which exposed the shared-queue design rather than causing it.

## Configurable, with fail-fast validation

`DOWNLOAD_QUEUE_CONCURRENCY` (15), `DOWNLOAD_QUEUE_TIMEOUT_MS` (100000), `DOWNLOAD_QUEUE_MAX_PENDING` (1000), `SYNCHRONIZER_QUEUE_CONCURRENCY` (10), `SYNCHRONIZER_QUEUE_TIMEOUT_MS` (100000), `CONTENT_FILES_CONCURRENCY` (4). All documented in `.env.default`.

Unset takes the default. A non-integer or `< 1` **throws at boot** rather than falling back — these size queues and in-flight budgets, and a value that silently resolves to `0` or `NaN` would either stall the pipeline or remove a bound entirely. Failing at startup is much cheaper than discovering it from a saturated dashboard.

## Why 15 and not 40

15 is deliberately conservative, not the best local number. The local measurements use folder storage and profile-heavy traffic, so they don't predict production, where S3 latency and scene content fan-out both differ. Ship a modest raise, watch `download_queue_size` / `download_queue_pending` and `entity_download_failure`, then tune via config — no code deploy needed.

**`CONTENT_FILES_CONCURRENCY` is lowered from the library default of 10** on purpose. snapshots-fetcher builds a *fresh PQueue per entity* and published v11 exposes no shared scheduler, so the real in-flight ceiling is the **product** of the two knobs. Widening the queue 5→15 while dropping content files 10→4 holds that product at 60 instead of letting it reach 150 — this PR should not quietly triple the load on community catalysts.

## Testing

`yarn build`, `yarn lint:check`, **92/92 tests** (9 suites). New coverage for the config parser (defaults, valid values, whitespace, and each rejection case). Two existing specs needed real fixes rather than assertion tweaks: the deployer's config mock returned one value for *every* key, which now also lands on `DOWNLOAD_QUEUE_MAX_PENDING`, so it is key-aware; and the entity-downloader call assertion gained the `contentFilesConcurrency` argument.
