### PR TITLE
feat: record processed deployments in postgres

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -30,6 +30,10 @@ ALLOWED_CONTENT_SERVER_HOSTS=peer.decentraland.org,peer-ec1.decentraland.org,pee
 # propagating old events downstream. Disabled when unset, 0, or non-numeric.
 ENTITY_MAX_AGE_IN_SECONDS=
 
+# Postgres holds the record of what has been processed. Set in the definitions repo in
+# deployed environments; point it at a local database for development.
+PG_COMPONENT_PSQL_CONNECTION_STRING=
+
 # --- Throughput tuning -------------------------------------------------------
 # All optional. Unset takes the default; a non-integer or < 1 fails at boot.
 # In-flight ceiling is DOWNLOAD_QUEUE_CONCURRENCY x CONTENT_FILES_CONCURRENCY.

--- a/package.json
+++ b/package.json
@@ -32,10 +32,13 @@
     "@dcl/fetch-component": "^1.1.2",
     "@dcl/http-server": "^2.4.0",
     "@dcl/metrics": "^1.0.1",
+    "@dcl/pg-component": "^0.2.1",
     "@dcl/schemas": "^15.3.3",
     "@dcl/snapshots-fetcher": "^11.0.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/interfaces": "^1.5.2",
-    "@well-known-components/logger": "^3.1.3"
+    "@well-known-components/logger": "^3.1.3",
+    "node-pg-migrate": "^7.9.1",
+    "sql-template-strings": "^2.2.2"
   }
 }

--- a/src/adapters/deployer/index.ts
+++ b/src/adapters/deployer/index.ts
@@ -10,6 +10,7 @@ export async function createDeployerComponent(
     | 'config'
     | 'logs'
     | 'storage'
+    | 'processedRegistry'
     | 'downloadQueue'
     | 'fetch'
     | 'metrics'
@@ -87,7 +88,7 @@ export async function createDeployerComponent(
           }
         }
 
-        const exists = await components.storage.exist(entity.entityId)
+        const exists = await components.processedRegistry.wasEntityPublished(entity.entityId)
 
         if (exists) {
           logger.debug('Entity already stored', {
@@ -115,9 +116,16 @@ export async function createDeployerComponent(
               components.metrics.decrement('download_queue_size')
               components.metrics.increment('download_queue_pending')
               try {
+                // Claim before downloading so an absent row always means "predates the table".
+                // Without it a failed publish would leave a stored object and no row, which the
+                // storage fallback reads as processed — the drop this replaces.
+                await components.processedRegistry.claimEntity(entity)
+
                 const metadata = await components.entityDownloader.downloadEntity(entity, servers)
 
                 await publishDeploymentNotifications({ ...entity, metadata }, servers)
+
+                await components.processedRegistry.markEntityPublished(entity.entityId)
 
                 await markAsDeployed()
 

--- a/src/adapters/processed-registry/index.ts
+++ b/src/adapters/processed-registry/index.ts
@@ -1,0 +1,105 @@
+import SQL from 'sql-template-strings'
+import { AppComponents, ProcessedRegistryComponent } from '../../types'
+
+/**
+ * Records what has been processed, in Postgres.
+ *
+ * Replaces the previous scheme where an object's presence in the bucket meant "done". That
+ * conflated "downloaded" with "published", so a failed SNS publish left the entity looking
+ * processed and it was never retried.
+ */
+export function createProcessedRegistryComponent(
+  components: Pick<AppComponents, 'pg' | 'storage' | 'logs'>
+): ProcessedRegistryComponent {
+  const { pg, storage } = components
+  const logger = components.logs.getLogger('ProcessedRegistry')
+
+  const snapshotKey = (hash: string) => `stored-snapshot-${hash}`
+
+  return {
+    async wasEntityPublished(entityId: string): Promise<boolean> {
+      const result = await pg.query<{ published_at: Date | null }>(
+        SQL`SELECT published_at FROM processed_entities WHERE entity_id = ${entityId}`
+      )
+
+      // A row is claimed before the download, so its absence means this entity predates the table.
+      // Those live only in the bucket, and treating them as unprocessed would replay every
+      // deployment since 2022. Removed in the PR that stops writing objects.
+      if (result.rowCount === 0) {
+        return storage.exist(entityId)
+      }
+
+      return result.rows[0].published_at !== null
+    },
+
+    async claimEntity(entity): Promise<void> {
+      await pg.query(
+        SQL`INSERT INTO processed_entities (entity_id, entity_type, entity_timestamp)
+            VALUES (${entity.entityId}, ${entity.entityType}, ${entity.entityTimestamp})
+            ON CONFLICT (entity_id) DO NOTHING`
+      )
+    },
+
+    async markEntityPublished(entityId: string): Promise<void> {
+      await pg.query(
+        SQL`UPDATE processed_entities SET published_at = now()
+            WHERE entity_id = ${entityId} AND published_at IS NULL`
+      )
+    },
+
+    async wasSnapshotProcessed(snapshotHash: string): Promise<boolean> {
+      const result = await pg.query(SQL`SELECT 1 FROM processed_snapshots WHERE snapshot_hash = ${snapshotHash}`)
+
+      return result.rowCount > 0 ? true : storage.exist(snapshotKey(snapshotHash))
+    },
+
+    async markSnapshotProcessed(snapshotHash: string): Promise<void> {
+      await pg.query(
+        SQL`INSERT INTO processed_snapshots (snapshot_hash) VALUES (${snapshotHash})
+            ON CONFLICT (snapshot_hash) DO NOTHING`
+      )
+    },
+
+    async filterProcessedSnapshots(snapshotHashes: string[]): Promise<Set<string>> {
+      if (snapshotHashes.length === 0) {
+        return new Set()
+      }
+
+      // One round trip for what used to be one S3 HEAD per hash, in sequence, for chunks of up to
+      // 1000. Hashes with no row still need the bucket check for the same pre-table reason as
+      // entities, but only those.
+      const result = await pg.query<{ snapshot_hash: string }>(
+        SQL`SELECT snapshot_hash FROM processed_snapshots WHERE snapshot_hash = ANY(${snapshotHashes})`
+      )
+
+      const processed = new Set(result.rows.map((row) => row.snapshot_hash))
+      const unknown = snapshotHashes.filter((hash) => !processed.has(hash))
+
+      for (const hash of unknown) {
+        if (await storage.exist(snapshotKey(hash))) {
+          processed.add(hash)
+        }
+      }
+
+      return processed
+    },
+
+    async countUnpublishedEntities(): Promise<number> {
+      const result = await pg.query<{ count: string }>(
+        SQL`SELECT count(*) AS count FROM processed_entities WHERE published_at IS NULL`
+      )
+
+      return Number(result.rows[0]?.count ?? 0)
+    },
+
+    async reportUnpublishedEntities(): Promise<void> {
+      try {
+        const stranded = await this.countUnpublishedEntities()
+        logger.info('Entities claimed but not published', { stranded })
+      } catch (error: any) {
+        // Reporting only — never block startup on it.
+        logger.warn('Could not count unpublished entities', { error: error?.message })
+      }
+    }
+  }
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -7,6 +7,8 @@ import {
 import { createLogComponent } from '@well-known-components/logger'
 import { createFetchComponent } from '@dcl/fetch-component'
 import { createMetricsComponent } from '@dcl/metrics'
+import { createPgComponent } from '@dcl/pg-component'
+import { resolve } from 'path'
 import { AppComponents, GlobalContext } from './types'
 import { getPositiveInt } from './logic/tuning'
 import { metricDeclarations } from './metrics'
@@ -22,10 +24,10 @@ import {
   createFolderBasedFileSystemContentStorage,
   createFsComponent
 } from '@dcl/catalyst-storage'
-import { Readable } from 'stream'
 import { createEntityDownloaderComponent } from './adapters/entity-downloader'
 import { createSnsDeploymentPublisherComponent, createSnsEventPublisherComponent } from './adapters/sns'
 import { createResilientContentStorage } from './adapters/storage'
+import { createProcessedRegistryComponent } from './adapters/processed-registry'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -51,6 +53,20 @@ export async function initComponents(): Promise<AppComponents> {
 
   const storage = createResilientContentStorage({ logs }, rawStorage)
 
+  const pg = await createPgComponent(
+    { logs, config, metrics },
+    {
+      migration: {
+        dir: resolve(__dirname, 'migrations'),
+        migrationsTable: 'pgmigrations',
+        ignorePattern: '.*\\.map',
+        direction: 'up'
+      }
+    }
+  )
+
+  const processedRegistry = createProcessedRegistryComponent({ pg, storage, logs })
+
   // Separate queues so `deployer.onIdle()` — awaited at every poll of every server — drains only
   // the deployer's work, and /snapshots fetches never queue behind an entity backlog.
   const downloadQueue = createJobQueue({
@@ -74,6 +90,7 @@ export async function initComponents(): Promise<AppComponents> {
   const deployer = await createDeployerComponent({
     config,
     storage,
+    processedRegistry,
     downloadQueue,
     fetch,
     logs,
@@ -83,30 +100,10 @@ export async function initComponents(): Promise<AppComponents> {
     entityDownloader
   })
 
-  const key = (hash: string) => `stored-snapshot-${hash}`
-
-  const snapshotStorageLogger = logs.getLogger('ISnapshotStorageComponent')
-
   const snapshotStorage: ISnapshotStorageComponent & IProcessedSnapshotStorageComponent = {
-    async has(snapshotHash: string) {
-      const exists = await storage.exist(key(snapshotHash))
-      snapshotStorageLogger.debug('HasSnapshot', { exists: exists ? 'true' : 'false', snapshotHash })
-      return exists
-    },
-    async markSnapshotAsProcessed(snapshotHash) {
-      snapshotStorageLogger.debug('MarkSnapshotAsProcessed', { snapshotHash })
-      await storage.storeStream(key(snapshotHash), Readable.from([]))
-    },
-    async filterProcessedSnapshotsFrom(snapshotHashes) {
-      snapshotStorageLogger.debug('FilterProcessedSnapshotsFrom', { cids: snapshotHashes.join(',') })
-      const ret = new Set<string>()
-      for (const hash of snapshotHashes) {
-        if (await storage.exist(key(hash))) {
-          ret.add(hash)
-        }
-      }
-      return ret
-    }
+    has: (snapshotHash) => processedRegistry.wasSnapshotProcessed(snapshotHash),
+    markSnapshotAsProcessed: (snapshotHash) => processedRegistry.markSnapshotProcessed(snapshotHash),
+    filterProcessedSnapshotsFrom: (snapshotHashes) => processedRegistry.filterProcessedSnapshots(snapshotHashes)
   }
 
   const synchronizer = await createSynchronizer(
@@ -155,6 +152,8 @@ export async function initComponents(): Promise<AppComponents> {
     metrics,
     storage,
     fs,
+    pg,
+    processedRegistry,
     downloadQueue,
     synchronizerQueue,
     synchronizer,

--- a/src/migrations/1755300000000_processed-deployments.ts
+++ b/src/migrations/1755300000000_processed-deployments.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { PgType } from 'node-pg-migrate'
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Replaces "an object exists in the bucket" as the record of what has been processed. A row is
+  // claimed before the download and stamped with published_at only after both SNS publishes
+  // succeed, so a publish failure stays retryable instead of being read as done.
+  pgm.createTable('processed_entities', {
+    entity_id: { type: PgType.TEXT, primaryKey: true },
+    entity_type: { type: PgType.TEXT, notNull: true },
+    entity_timestamp: { type: PgType.BIGINT, notNull: true },
+    published_at: { type: PgType.TIMESTAMP_WITH_TIME_ZONE },
+    created_at: { type: PgType.TIMESTAMP_WITH_TIME_ZONE, notNull: true, default: pgm.func('now()') }
+  })
+
+  // Finds entities claimed but never published — the set the pre-fix bug stranded. Partial so it
+  // stays small: rows are only in it while unpublished, which is normally near-zero.
+  pgm.createIndex('processed_entities', 'created_at', {
+    name: 'processed_entities_unpublished_idx',
+    where: 'published_at IS NULL'
+  })
+
+  // Replaces the zero-byte `stored-snapshot-<hash>` objects.
+  pgm.createTable('processed_snapshots', {
+    snapshot_hash: { type: PgType.TEXT, primaryKey: true },
+    created_at: { type: PgType.TIMESTAMP_WITH_TIME_ZONE, notNull: true, default: pgm.func('now()') }
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('processed_snapshots')
+  pgm.dropTable('processed_entities')
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -48,5 +48,8 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
   // start ports: db, listeners, synchronizations, etc
   await startComponents()
 
+  // Surfaces entities the pre-Postgres dedup stranded: claimed/stored but never published.
+  await components.processedRegistry.reportUnpublishedEntities()
+
   await components.synchronizer.syncWithServers(new Set(servers))
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import type {
   IMetricsComponent
 } from '@well-known-components/interfaces'
 import { IContentStorageComponent, IFileSystemComponent } from '@dcl/catalyst-storage'
+import { IPgComponent } from '@dcl/pg-component'
 import { metricDeclarations } from './metrics'
 
 export type GlobalContext = {
@@ -26,6 +27,8 @@ export type BaseComponents = {
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
   fs: IFileSystemComponent
   storage: IContentStorageComponent
+  pg: IPgComponent
+  processedRegistry: ProcessedRegistryComponent
   synchronizer: SynchronizerComponent
   deployer: IDeployerComponent
   snsPublisher: SnsPublisherComponent
@@ -35,6 +38,18 @@ export type BaseComponents = {
 
 export type SnsPublisherComponent = {
   publishMessage: (entity: DeployableEntity & { metadata: any }, contentServerUrls: string[]) => Promise<void>
+}
+
+/** Records what has been processed. Backed by Postgres, falling back to storage for pre-table entities. */
+export type ProcessedRegistryComponent = {
+  wasEntityPublished: (entityId: string) => Promise<boolean>
+  claimEntity: (entity: Pick<DeployableEntity, 'entityId' | 'entityType' | 'entityTimestamp'>) => Promise<void>
+  markEntityPublished: (entityId: string) => Promise<void>
+  wasSnapshotProcessed: (snapshotHash: string) => Promise<boolean>
+  markSnapshotProcessed: (snapshotHash: string) => Promise<void>
+  filterProcessedSnapshots: (snapshotHashes: string[]) => Promise<Set<string>>
+  countUnpublishedEntities: () => Promise<number>
+  reportUnpublishedEntities: () => Promise<void>
 }
 
 export type EntityDownloaderComponent = {

--- a/test/components.ts
+++ b/test/components.ts
@@ -7,7 +7,7 @@ import { main } from '../src/service'
 import { TestComponents } from '../src/types'
 import { initComponents as originalInitComponents } from '../src/components'
 import { createInMemoryStorage } from '@dcl/catalyst-storage'
-import { configMock, metricsMock } from './mocks/components'
+import { configMock, metricsMock, pgMock, processedRegistryMock } from './mocks/components'
 
 /**
  * Behaves like Jest "describe" function, used to describe a test for a
@@ -37,6 +37,10 @@ async function initComponents(): Promise<TestComponents> {
     // Stub the synchronizer so `main()` doesn't kick off a real catalyst sync
     // during tests (CONTENT_SERVER_URLS now resolves to a real allowlisted host
     // to satisfy the startup allowlist guard).
-    synchronizer: { syncWithServers: jest.fn().mockResolvedValue({}) } as any
+    synchronizer: { syncWithServers: jest.fn().mockResolvedValue({}) } as any,
+    // Stubbed so the suite needs no database: the real component would connect and
+    // run migrations on start. Registry behaviour is covered by its own unit tests.
+    pg: pgMock,
+    processedRegistry: processedRegistryMock
   }
 }

--- a/test/mocks/components.ts
+++ b/test/mocks/components.ts
@@ -1,7 +1,7 @@
 import { IContentStorageComponent } from '@dcl/catalyst-storage'
 import { IFetchComponent } from '@dcl/core-commons'
 import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
-import { EntityDownloaderComponent, SnsPublisherComponent } from '../../src/types'
+import { EntityDownloaderComponent, ProcessedRegistryComponent, SnsPublisherComponent } from '../../src/types'
 import { IJobQueue } from '@dcl/snapshots-fetcher'
 
 export const configMock: jest.Mocked<IConfigComponent> = {
@@ -36,6 +36,27 @@ export const logsMock: jest.Mocked<ILoggerComponent> = {
 
 export const fetcherMock: jest.Mocked<IFetchComponent> = {
   fetch: jest.fn()
+}
+
+export const pgMock: jest.Mocked<any> = {
+  query: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+  streamQuery: jest.fn(),
+  withTransaction: jest.fn(),
+  withAsyncContextTransaction: jest.fn(),
+  getPool: jest.fn()
+}
+
+export const processedRegistryMock: jest.Mocked<ProcessedRegistryComponent> = {
+  wasEntityPublished: jest.fn(),
+  claimEntity: jest.fn(),
+  markEntityPublished: jest.fn(),
+  wasSnapshotProcessed: jest.fn(),
+  markSnapshotProcessed: jest.fn(),
+  filterProcessedSnapshots: jest.fn(),
+  countUnpublishedEntities: jest.fn(),
+  reportUnpublishedEntities: jest.fn()
 }
 
 export const storageMock: jest.Mocked<IContentStorageComponent> = {

--- a/test/unit/adapters/deployer.spec.ts
+++ b/test/unit/adapters/deployer.spec.ts
@@ -8,7 +8,8 @@ import {
   metricsMock,
   snsPublisherMock,
   entityDownloaderMock,
-  downloadQueueMock
+  downloadQueueMock,
+  processedRegistryMock
 } from '../../mocks/components'
 import { DeployableEntity, IDeployerComponent } from '@dcl/snapshots-fetcher'
 
@@ -19,6 +20,7 @@ describe('DeployerComponent', () => {
       | 'config'
       | 'logs'
       | 'storage'
+      | 'processedRegistry'
       | 'downloadQueue'
       | 'fetch'
       | 'metrics'
@@ -47,6 +49,7 @@ describe('DeployerComponent', () => {
       config: configMock,
       logs: logsMock,
       storage: storageMock,
+      processedRegistry: processedRegistryMock,
       downloadQueue: downloadQueueMock,
       fetch: fetcherMock,
       metrics: metricsMock,
@@ -83,12 +86,12 @@ describe('DeployerComponent', () => {
       entityType: maliciousEntity.entityType
     })
     expect(maliciousEntity.markAsDeployed).toHaveBeenCalled()
-    expect(storageMock.exist).not.toHaveBeenCalled()
+    expect(processedRegistryMock.wasEntityPublished).not.toHaveBeenCalled()
     expect(entityDownloaderMock.downloadEntity).not.toHaveBeenCalled()
   })
 
   it('should call mark as deployed when the entity is already stored', async () => {
-    storageMock.exist.mockResolvedValue(true)
+    processedRegistryMock.wasEntityPublished.mockResolvedValue(true)
 
     const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
@@ -102,7 +105,7 @@ describe('DeployerComponent', () => {
   })
 
   it('should do nothing if the entity is already stored but does not define a markAsDeployed function', async () => {
-    storageMock.exist.mockResolvedValue(true)
+    processedRegistryMock.wasEntityPublished.mockResolvedValue(true)
 
     const mockEntityWithoutMarkAsDeployed = { ...mockEntity, markAsDeployed: undefined }
 
@@ -117,7 +120,7 @@ describe('DeployerComponent', () => {
   })
 
   it('should successfully deploy a new entity', async () => {
-    storageMock.exist.mockResolvedValue(false)
+    processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
     entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
     snsPublisherMock.publishMessage.mockResolvedValue()
 
@@ -140,11 +143,13 @@ describe('DeployerComponent', () => {
   })
 
   it('should handle retryable errors gracefully', async () => {
-    storageMock.exist.mockResolvedValue(false)
+    processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
     entityDownloaderMock.downloadEntity.mockRejectedValue(new Error('Network Error'))
 
     const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+
+    await jest.advanceTimersByTimeAsync(0)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
       retryable: 'true',
@@ -154,11 +159,13 @@ describe('DeployerComponent', () => {
   })
 
   it('should handle non-retryable errors and mark the entity as deployed', async () => {
-    storageMock.exist.mockResolvedValue(false)
+    processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
     entityDownloaderMock.downloadEntity.mockRejectedValue(new Error('status: 404'))
 
     const deployer = await createDeployerComponent(components)
     await deployer.scheduleEntityDeployment(mockEntity, mockServers)
+
+    await jest.advanceTimersByTimeAsync(0)
 
     expect(metricsMock.increment).toHaveBeenCalledWith('entity_deployment_failure', {
       retryable: 'false',
@@ -168,7 +175,7 @@ describe('DeployerComponent', () => {
   })
 
   it('should handle errors before scheduling the job', async () => {
-    storageMock.exist.mockResolvedValue(false)
+    processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
     downloadQueueMock.onSizeLessThan.mockRejectedValue(new Error('Queue Error'))
 
     const deployer = await createDeployerComponent(components)
@@ -195,7 +202,7 @@ describe('DeployerComponent', () => {
         entityType: oldEntity.entityType
       })
       expect(oldEntity.markAsDeployed).toHaveBeenCalled()
-      expect(storageMock.exist).not.toHaveBeenCalled()
+      expect(processedRegistryMock.wasEntityPublished).not.toHaveBeenCalled()
       expect(downloadQueueMock.onSizeLessThan).not.toHaveBeenCalled()
       expect(entityDownloaderMock.downloadEntity).not.toHaveBeenCalled()
     })
@@ -203,7 +210,7 @@ describe('DeployerComponent', () => {
     it('should process recent entities normally when the age filter is enabled', async () => {
       const maxAgeInSeconds = 3600
       setEntityMaxAge(String(maxAgeInSeconds))
-      storageMock.exist.mockResolvedValue(false)
+      processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
       entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
       snsPublisherMock.publishMessage.mockResolvedValue()
 
@@ -220,7 +227,7 @@ describe('DeployerComponent', () => {
     it('should not skip an entity aged exactly at the threshold', async () => {
       const maxAgeInSeconds = 3600
       setEntityMaxAge(String(maxAgeInSeconds))
-      storageMock.exist.mockResolvedValue(false)
+      processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
       entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
       snsPublisherMock.publishMessage.mockResolvedValue()
       const boundaryEntity = { ...mockEntity, entityTimestamp: Date.now() - maxAgeInSeconds * 1000 }
@@ -231,7 +238,7 @@ describe('DeployerComponent', () => {
       await jest.advanceTimersByTimeAsync(0)
 
       expect(metricsMock.increment).not.toHaveBeenCalledWith('entity_skipped_old', expect.anything())
-      expect(storageMock.exist).toHaveBeenCalled()
+      expect(processedRegistryMock.wasEntityPublished).toHaveBeenCalled()
       expect(entityDownloaderMock.downloadEntity).toHaveBeenCalledWith(boundaryEntity, mockServers)
     })
 
@@ -239,7 +246,7 @@ describe('DeployerComponent', () => {
       'should process all entities when config is "%s" (filter disabled)',
       async (configValue) => {
         setEntityMaxAge(configValue)
-        storageMock.exist.mockResolvedValue(false)
+        processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
         entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
         snsPublisherMock.publishMessage.mockResolvedValue()
         const oldTimestamp = Date.now() - 10 * 365 * 24 * 3600 * 1000
@@ -274,7 +281,7 @@ describe('DeployerComponent', () => {
       onUnhandled = (reason: unknown) => unhandled.push(reason)
       process.on('unhandledRejection', onUnhandled)
 
-      storageMock.exist.mockResolvedValue(false)
+      processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
       downloadQueueMock.scheduleJob.mockRejectedValue(queueError)
 
       const deployer = await createDeployerComponent(components)
@@ -306,7 +313,7 @@ describe('DeployerComponent', () => {
   describe('when tracking download queue depth', () => {
     describe('and a job is scheduled and runs to completion', () => {
       beforeEach(async () => {
-        storageMock.exist.mockResolvedValue(false)
+        processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
         entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
         snsPublisherMock.publishMessage.mockResolvedValue()
 
@@ -328,7 +335,7 @@ describe('DeployerComponent', () => {
 
     describe('and the job fails', () => {
       beforeEach(async () => {
-        storageMock.exist.mockResolvedValue(false)
+        processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
         entityDownloaderMock.downloadEntity.mockRejectedValue(new Error('boom'))
 
         const deployer = await createDeployerComponent(components)
@@ -348,7 +355,7 @@ describe('DeployerComponent', () => {
       let pendingDelta: number
 
       beforeEach(async () => {
-        storageMock.exist.mockResolvedValue(false)
+        processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
         entityDownloaderMock.downloadEntity.mockResolvedValue(undefined)
         snsPublisherMock.publishMessage.mockResolvedValue()
         downloadQueueMock.scheduleJob.mockImplementation(async (fn) => {
@@ -385,7 +392,7 @@ describe('DeployerComponent', () => {
 
     describe('and the queue refuses the job because it has been stopped', () => {
       beforeEach(async () => {
-        storageMock.exist.mockResolvedValue(false)
+        processedRegistryMock.wasEntityPublished.mockResolvedValue(false)
         downloadQueueMock.scheduleJob.mockImplementation(() => {
           throw new Error('The job queue was stopped and no longer accepts jobs')
         })

--- a/test/unit/adapters/processed-registry.spec.ts
+++ b/test/unit/adapters/processed-registry.spec.ts
@@ -1,0 +1,151 @@
+import { createProcessedRegistryComponent } from '../../../src/adapters/processed-registry'
+import { ProcessedRegistryComponent } from '../../../src/types'
+import { logsMock, pgMock, storageMock } from '../../mocks/components'
+
+const rows = <T>(values: T[]) => ({ rows: values, rowCount: values.length })
+
+describe('ProcessedRegistryComponent', () => {
+  let registry: ProcessedRegistryComponent
+
+  beforeEach(() => {
+    logsMock.getLogger.mockReturnValue({
+      log: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn()
+    })
+    registry = createProcessedRegistryComponent({ pg: pgMock, storage: storageMock, logs: logsMock })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when checking whether an entity was published', () => {
+    describe('and it has a row stamped with published_at', () => {
+      let result: boolean
+
+      beforeEach(async () => {
+        pgMock.query.mockResolvedValueOnce(rows([{ published_at: new Date() }]))
+        result = await registry.wasEntityPublished('an-entity')
+      })
+
+      it('should report it as published', () => {
+        expect(result).toBe(true)
+      })
+
+      it('should not consult storage, since the table already answered', () => {
+        expect(storageMock.exist).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and it has a row with no published_at, because a publish failed', () => {
+      let result: boolean
+
+      beforeEach(async () => {
+        pgMock.query.mockResolvedValueOnce(rows([{ published_at: null }]))
+        // The object is present — the download succeeded before the publish failed. This is the
+        // exact case the old presence-based dedup got wrong.
+        storageMock.exist.mockResolvedValue(true)
+        result = await registry.wasEntityPublished('an-entity')
+      })
+
+      it('should report it as NOT published, so it is retried', () => {
+        expect(result).toBe(false)
+      })
+
+      it('should not let a stored object override the row', () => {
+        expect(storageMock.exist).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and it has no row but an object exists, i.e. it predates the table', () => {
+      let result: boolean
+
+      beforeEach(async () => {
+        pgMock.query.mockResolvedValueOnce(rows([]))
+        storageMock.exist.mockResolvedValue(true)
+        result = await registry.wasEntityPublished('a-legacy-entity')
+      })
+
+      it('should report it as published, so history is not replayed', () => {
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('and it has neither a row nor an object', () => {
+      let result: boolean
+
+      beforeEach(async () => {
+        pgMock.query.mockResolvedValueOnce(rows([]))
+        storageMock.exist.mockResolvedValue(false)
+        result = await registry.wasEntityPublished('a-new-entity')
+      })
+
+      it('should report it as not published', () => {
+        expect(result).toBe(false)
+      })
+    })
+  })
+
+  describe('when filtering processed snapshots', () => {
+    describe('and some are in the table and some only in storage', () => {
+      let result: Set<string>
+
+      beforeEach(async () => {
+        pgMock.query.mockResolvedValueOnce(rows([{ snapshot_hash: 'in-table' }]))
+        storageMock.exist.mockImplementation(async (key: string) => key.endsWith('in-storage'))
+        result = await registry.filterProcessedSnapshots(['in-table', 'in-storage', 'unprocessed'])
+      })
+
+      it('should report both the table and the storage hits as processed', () => {
+        expect(result).toEqual(new Set(['in-table', 'in-storage']))
+      })
+
+      it('should query the table once for the whole batch rather than per hash', () => {
+        expect(pgMock.query).toHaveBeenCalledTimes(1)
+      })
+
+      it('should only fall back to storage for hashes the table did not answer', () => {
+        expect(storageMock.exist).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe('and the batch is empty', () => {
+      let result: Set<string>
+
+      beforeEach(async () => {
+        result = await registry.filterProcessedSnapshots([])
+      })
+
+      it('should return nothing without touching the database', () => {
+        expect(result).toEqual(new Set())
+        expect(pgMock.query).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when counting entities that were claimed but never published', () => {
+    let count: number
+
+    beforeEach(async () => {
+      pgMock.query.mockResolvedValueOnce(rows([{ count: '42' }]))
+      count = await registry.countUnpublishedEntities()
+    })
+
+    it('should return the count as a number, not the string postgres returns', () => {
+      expect(count).toBe(42)
+    })
+  })
+
+  describe('when reporting the unpublished count and the query fails', () => {
+    beforeEach(() => {
+      pgMock.query.mockRejectedValue(new Error('database is down'))
+    })
+
+    it('should not throw, since reporting must never block startup', async () => {
+      await expect(registry.reportUnpublishedEntities()).resolves.toBeUndefined()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,6 +1057,18 @@
   dependencies:
     prom-client "^15.1.0"
 
+"@dcl/pg-component@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@dcl/pg-component/-/pg-component-0.2.1.tgz#392759314e0679bce4623125b03a517d856ece9c"
+  integrity sha512-bh3KV5ToMZLzQvescuYUvYBVYh8i6E0awSGRwL8KD0UZer3Kx6SuTVyu11O6oPHSKrsnt4Y6pY2ApPQiZVbkIg==
+  dependencies:
+    "@well-known-components/interfaces" "^1.5.2"
+    node-pg-migrate "^7.9.1"
+    pg "8.17.2"
+    pg-protocol "^1.11.0"
+    pg-query-stream "4.11.2"
+    sql-template-strings "2.2.2"
+
 "@dcl/schemas@^15.3.3":
   version "15.3.3"
   resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-15.3.3.tgz#29b35d4eb1af0085cb09e79ecdc39a0c074f59a9"
@@ -1159,6 +1171,11 @@
   version "2.0.1"
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz"
   integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
+
+"@isaacs/cliui@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-9.0.0.tgz#4d0a3f127058043bf2e7ee169eaf30ed901302f3"
+  integrity sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2334,6 +2351,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 base64-js@^1.0.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2356,6 +2378,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^5.0.8:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -2526,9 +2555,9 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
@@ -3044,6 +3073,14 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+foreground-child@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 form-data@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
@@ -3125,6 +3162,18 @@ glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@~11.0.0:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.3.tgz#9d8087e6d72ddb3c4707b1d2778f80ea3eaefcd6"
+  integrity sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==
+  dependencies:
+    foreground-child "^3.3.1"
+    jackspeak "^4.1.1"
+    minimatch "^10.0.3"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^2.0.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -3348,6 +3397,13 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jackspeak@^4.1.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.2.3.tgz#27ef80f33b93412037c3bea4f8eddf80e1931483"
+  integrity sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==
+  dependencies:
+    "@isaacs/cliui" "^9.0.0"
 
 jest-changed-files@^29.7.0:
   version "29.7.0"
@@ -3829,6 +3885,11 @@ lodash@^4.17.20:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lru-cache@^11.0.0:
+  version "11.5.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.2.tgz#00e16665c90c620fba14a3c368732a976493f760"
+  integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"
@@ -3897,12 +3958,24 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+minimatch@^10.0.3:
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
+  integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
+  dependencies:
+    brace-expansion "^5.0.8"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 mitt@^3.0.0, mitt@^3.0.1:
   version "3.0.1"
@@ -3933,6 +4006,14 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
+
+node-pg-migrate@^7.9.1:
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/node-pg-migrate/-/node-pg-migrate-7.9.1.tgz#b8b9b7dafa6321e9567171ea20649a3146656c69"
+  integrity sha512-6z4OSN27ye8aYdX9ZU7NN2PTI5pOp34hTr+22Ej12djIYECq++gT7LPLZVOQXEeVCBOZQLqf87kC3Y36G434OQ==
+  dependencies:
+    glob "~11.0.0"
+    yargs "~17.7.0"
 
 node-releases@^2.0.13:
   version "2.0.13"
@@ -4044,6 +4125,11 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -4086,6 +4172,14 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
+
 path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
@@ -4095,6 +4189,74 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pg-cloudflare@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz#4b4c20e6d8ae531d400730f4804571a8d62f1497"
+  integrity sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==
+
+pg-connection-string@^2.10.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz#abc26ee4f37c56c0f3ae0fcf0b0653cc4e1c0fd9"
+  integrity sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==
+
+pg-cursor@^2.16.2:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.22.0.tgz#2d739638e535025ff39d35f5b5f71e0354ab3305"
+  integrity sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.11.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.14.0.tgz#f35ae4eb846780cad71af24099b3edfa9781ad90"
+  integrity sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==
+
+pg-protocol@^1.11.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.16.0.tgz#cffb008826561ee9770a8a15dc21f269d731b305"
+  integrity sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==
+
+pg-query-stream@4.11.2:
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/pg-query-stream/-/pg-query-stream-4.11.2.tgz#004762649ab31981ea9dd4c4a4d7ae0340c59f97"
+  integrity sha512-OKI6FKLTawfaAlKo5koHZ3K3Ce+FywB1IF8IDEnCjsGULlbKsGniP9LsT5uKTNNCqLmK7EBp5gAqPFLJS28h6g==
+  dependencies:
+    pg-cursor "^2.16.2"
+
+pg-types@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@8.17.2:
+  version "8.17.2"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.17.2.tgz#8df8c039c36bb97016be276094fc4991e8683963"
+  integrity sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==
+  dependencies:
+    pg-connection-string "^2.10.1"
+    pg-pool "^3.11.0"
+    pg-protocol "^1.11.0"
+    pg-types "2.2.0"
+    pgpass "1.0.5"
+  optionalDependencies:
+    pg-cloudflare "^1.3.0"
+
+pgpass@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -4124,6 +4286,28 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4305,6 +4489,11 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
@@ -4328,10 +4517,20 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+sql-template-strings@2.2.2, sql-template-strings@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/sql-template-strings/-/sql-template-strings-2.2.2.tgz#3f11508a25addfce217a3042a9d300c3193b96ff"
+  integrity sha512-UXhXR2869FQaD+GMly8jAMCRZ94nU5KcrFetZfWEMd+LVVG6y0ExgHAhatEcKZ/wk8YcKPdi+hiD2wm75lq3/Q==
 
 stack-utils@^2.0.3:
   version "2.0.6"
@@ -4652,6 +4851,11 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
@@ -4676,6 +4880,19 @@ yargs@^17.3.1:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@~17.7.0:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
PR 1 of 3. Replaces "an object exists in the bucket" as the record of what has been processed.

## The bug it fixes

Object presence conflated *downloaded* with *published*. If an SNS publish failed, `markAsDeployed()` was correctly skipped so the entity would retry — but the download had already written the object, so on retry `exist()` said "already stored" and the entity was marked deployed **without ever being published**.

Reproduced against a real catalyst with a dummy SNS ARN, restarting on the same storage:

```
phase 1:  1,648 stored   0 published   5,566 publish failures
phase 2:  1,657 skipped as "already stored"   ← never published, never will be
```

An SNS outage didn't delay deployments, it lost them.

## The fix

A row is claimed **before** the download and stamped with `published_at` only after both publishes succeed:

```
row present  → processed only if published_at is set
no row       → fall back to storage.exist()
```

**Two details that look redundant and aren't.** The `storage.exist()` fallback is a migration step — every entity processed since 2022 exists only as an S3 object, and a table-only check would treat the entire bucket as unprocessed and replay years of deployments at the converter. And claiming *before* the download is what makes "no row" mean "predates the table" rather than "publish failed" — without it the fallback would reintroduce the exact bug being fixed. There's a test for that case; removing either piece fails it.

## Also

`filterProcessedSnapshotsFrom` resolves a batch in **one query** instead of up to 1,000 sequential S3 HEADs, falling back to storage only for hashes the table doesn't know. That was old plan PR 4, now free.

`published_at IS NULL` identifies stranded entities and the count is logged at startup. It only covers entities seen since this ships — ones stranded historically have an object and no row, indistinguishable from never-seen ones.

## Before deploying

Postgres runs on the shared `supra` cluster already used by 34 services, but **the database and user need provisioning**, and `PG_COMPONENT_PSQL_CONNECTION_STRING` must be set in `definitions`. This will fail at startup without them.

## Testing

`yarn build`, `yarn lint:check`, **107/107** tests (10 suites). New registry suite covers all four dedup states, batch filtering, and that reporting never blocks startup. The integration harness stubs `pg` so the suite needs no database.
